### PR TITLE
Add forward query support for datasources

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybirdco/sdk",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "TypeScript SDK for Tinybird Forward - define datasources and pipes as TypeScript",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/api/resources.ts
+++ b/src/api/resources.ts
@@ -75,6 +75,8 @@ export interface DatasourceInfo {
   columns: DatasourceColumn[];
   /** Engine configuration */
   engine: DatasourceEngine;
+  /** Forward query for schema evolution */
+  forward_query?: string;
 }
 
 /**
@@ -135,6 +137,7 @@ interface DatasourceDetailResponse {
   partition_key?: string;
   primary_key?: string;
   ttl?: string;
+  forward_query?: string;
 }
 
 // ============ Pipe Types ============
@@ -376,6 +379,7 @@ export async function getDatasource(
       version: engineObj?.engine_version,
       summing_columns: engineObj?.engine_summing_columns,
     },
+    forward_query: data.forward_query,
   };
 }
 

--- a/src/codegen/index.test.ts
+++ b/src/codegen/index.test.ts
@@ -74,6 +74,18 @@ describe("generateDatasourceCode", () => {
     expect(code).toContain(" * Event tracking data");
     expect(code).toContain(" */");
   });
+
+  it("includes forward query when present", () => {
+    const ds: DatasourceInfo = {
+      name: "events",
+      columns: [{ name: "id", type: "String" }],
+      engine: { type: "MergeTree", sorting_key: "id" },
+      forward_query: "SELECT id",
+    };
+
+    const code = generateDatasourceCode(ds);
+    expect(code).toContain("forwardQuery: `SELECT id`");
+  });
 });
 
 describe("generatePipeCode", () => {

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -45,6 +45,11 @@ export function generateDatasourceCode(ds: DatasourceInfo): string {
   const engineCode = generateEngineCode(ds.engine);
   lines.push(`  engine: ${engineCode},`);
 
+  if (ds.forward_query) {
+    const formattedQuery = formatSqlForTemplate(ds.forward_query);
+    lines.push(`  forwardQuery: \`${formattedQuery}\`,`);
+  }
+
   lines.push("});");
   lines.push("");
   lines.push(`export type ${typeName}Row = InferRow<typeof ${varName}>;`);

--- a/src/generator/datasource.test.ts
+++ b/src/generator/datasource.test.ts
@@ -81,6 +81,19 @@ describe('Datasource Generator', () => {
       const result = generateDatasource(ds);
       expect(result.content).toContain('ENGINE_TTL "timestamp + INTERVAL 90 DAY"');
     });
+
+    it('includes forward query when provided', () => {
+      const ds = defineDatasource('test_ds', {
+        schema: {
+          id: t.string(),
+        },
+        forwardQuery: 'SELECT id',
+      });
+
+      const result = generateDatasource(ds);
+      expect(result.content).toContain('FORWARD_QUERY >');
+      expect(result.content).toContain('    SELECT id');
+    });
   });
 
   describe('Column formatting', () => {

--- a/src/generator/datasource.ts
+++ b/src/generator/datasource.ts
@@ -164,6 +164,23 @@ function generateKafkaConfig(kafka: KafkaConfig): string {
 }
 
 /**
+ * Generate forward query section
+ */
+function generateForwardQuery(forwardQuery?: string): string | null {
+  if (!forwardQuery) {
+    return null;
+  }
+
+  const trimmed = forwardQuery.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const lines = trimmed.split(/\r?\n/);
+  return ["FORWARD_QUERY >", ...lines.map((line) => `    ${line}`)].join("\n");
+}
+
+/**
  * Generate a .datasource file content from a DatasourceDefinition
  *
  * @param datasource - The datasource definition
@@ -222,6 +239,13 @@ export function generateDatasource(
   if (datasource.options.kafka) {
     parts.push("");
     parts.push(generateKafkaConfig(datasource.options.kafka));
+  }
+
+  // Add forward query if present
+  const forwardQuery = generateForwardQuery(datasource.options.forwardQuery);
+  if (forwardQuery) {
+    parts.push("");
+    parts.push(forwardQuery);
   }
 
   return {

--- a/src/schema/datasource.ts
+++ b/src/schema/datasource.ts
@@ -71,6 +71,11 @@ export interface DatasourceOptions<TSchema extends SchemaDefinition> {
    * Defaults to true.
    */
   jsonPaths?: boolean;
+  /**
+   * Forward query used to evolve a datasource with incompatible schema changes.
+   * This should be the SELECT clause only (no FROM/WHERE).
+   */
+  forwardQuery?: string;
   /** Kafka ingestion configuration */
   kafka?: KafkaConfig;
 }


### PR DESCRIPTION
Adds a forwardQuery option to datasource definitions and emits FORWARD_QUERY in generated .datasource files. Plumbs forward_query from the API into codegen and adds coverage.