### PR TITLE
docs: add runtime requirements to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,25 @@ A TypeScript SDK for defining Tinybird resources with full type inference. Defin
 npm install @tinybirdco/sdk
 ```
 
+## Requirements
+
+TypeScript `>=4.9` is supported for consumers.
+
+Officially supported runtime:
+- Node.js 20 LTS or later non-EOL versions
+
+Not officially supported (untested in this repository at this time):
+- Deno `>=1.28.0`
+- Bun `>=1.0.0`
+- Cloudflare Workers
+- Vercel Edge Runtime
+- Jest `>=28` (including `"node"` environment)
+- Nitro `>=2.6.0`
+
+Web browsers are not supported. This SDK is designed for server-side usage and using it directly in the browser may expose Tinybird API credentials.
+
+If you need support for other runtimes, please open or upvote an issue on GitHub.
+
 ## Quick Start
 
 ### 1. Initialize your project


### PR DESCRIPTION
## Summary\n- add a new Requirements section to the README\n- document TypeScript support (>=4.9)\n- clarify officially supported runtime (Node.js 20+ non-EOL)\n- explicitly mark browsers as unsupported and list other runtimes as untested/non-official\n\n## Validation\n- docs-only change