### PR TITLE
feat: add gitBranch to ClientContext

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybirdco/sdk",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "TypeScript SDK for Tinybird Forward - define datasources and pipes as TypeScript",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/client/base.test.ts
+++ b/src/client/base.test.ts
@@ -48,6 +48,7 @@ describe("TinybirdClient", () => {
         devMode: false,
         isBranchToken: false,
         branchName: null,
+        gitBranch: null,
       });
     });
 
@@ -79,6 +80,16 @@ describe("TinybirdClient", () => {
 
       const context = await client.getContext();
       expect(context.branchName).toBeNull();
+    });
+
+    it("returns gitBranch: null when not in devMode", async () => {
+      const client = new TinybirdClient({
+        baseUrl: "https://api.tinybird.co",
+        token: "test-token",
+      });
+
+      const context = await client.getContext();
+      expect(context.gitBranch).toBeNull();
     });
 
     it("caches the resolved context", async () => {

--- a/src/client/base.ts
+++ b/src/client/base.ts
@@ -20,6 +20,7 @@ interface ResolvedTokenInfo {
   token: string;
   isBranchToken: boolean;
   branchName?: string;
+  gitBranch?: string;
 }
 
 /**
@@ -118,6 +119,7 @@ export class TinybirdClient {
       devMode: this.config.devMode ?? false,
       isBranchToken: tokenInfo.isBranchToken,
       branchName: tokenInfo.branchName ?? null,
+      gitBranch: tokenInfo.gitBranch ?? null,
     };
   }
 
@@ -132,10 +134,11 @@ export class TinybirdClient {
       const { getOrCreateBranch } = await import("../api/branches.js");
 
       const config = loadConfig();
+      const gitBranch = config.gitBranch ?? undefined;
 
       // If on main branch, use the workspace token
       if (config.isMainBranch || !config.tinybirdBranch) {
-        return this.buildContext({ token: this.config.token, isBranchToken: false });
+        return this.buildContext({ token: this.config.token, isBranchToken: false, gitBranch });
       }
 
       const branchName = config.tinybirdBranch;
@@ -148,13 +151,14 @@ export class TinybirdClient {
 
       if (!branch.token) {
         // Fall back to workspace token if no branch token
-        return this.buildContext({ token: this.config.token, isBranchToken: false });
+        return this.buildContext({ token: this.config.token, isBranchToken: false, gitBranch });
       }
 
       return this.buildContext({
         token: branch.token,
         isBranchToken: true,
         branchName,
+        gitBranch,
       });
     } catch {
       // If anything fails, fall back to the workspace token

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -160,8 +160,10 @@ export interface ClientContext {
   devMode: boolean;
   /** Whether the resolved token is a branch token (vs workspace token) */
   isBranchToken: boolean;
-  /** The branch name if using a branch token */
+  /** The Tinybird branch name if using a branch token (sanitized for Tinybird) */
   branchName: string | null;
+  /** The current git branch name (null if not in a git repo or devMode is disabled) */
+  gitBranch: string | null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds `gitBranch` field to `ClientContext` interface to expose the current git branch name
- Returns the original git branch name (e.g., `feature/my-branch`) alongside the sanitized Tinybird branch name
- Field is `null` when devMode is disabled or not in a git repo

## Test plan
- [x] Added unit test for `gitBranch: null` when not in devMode
- [x] Updated existing context assertion to include `gitBranch` field
- [x] All unit tests pass (13 tests in base.test.ts)
- [x] TypeScript compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)