### PR TITLE
fix: resolve tinybird.json config in monorepo setups

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybirdco/sdk",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "description": "TypeScript SDK for Tinybird Forward - define datasources and pipes as TypeScript",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/client/base.ts
+++ b/src/client/base.ts
@@ -133,7 +133,9 @@ export class TinybirdClient {
       const { loadConfig } = await import("../cli/config.js");
       const { getOrCreateBranch } = await import("../api/branches.js");
 
-      const config = loadConfig();
+      // Use configDir if provided (important for monorepo setups where process.cwd()
+      // may not be in the same directory tree as tinybird.json)
+      const config = loadConfig(this.config.configDir);
       const gitBranch = config.gitBranch ?? undefined;
 
       // If on main branch, use the workspace token

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -20,6 +20,13 @@ export interface ClientConfig {
    * Tinybird branch token instead of the workspace token.
    */
   devMode?: boolean;
+  /**
+   * Directory to use as the starting point when searching for tinybird.json config.
+   * In monorepo setups, this should be set to the directory containing tinybird.json
+   * to ensure the config is found regardless of where the application runs from.
+   * Typically derived from import.meta.url in the generated client.
+   */
+  configDir?: string;
 }
 
 /**

--- a/src/codegen/index.test.ts
+++ b/src/codegen/index.test.ts
@@ -313,6 +313,18 @@ describe("generateClientFile", () => {
     expect(file).toContain("export { events, topEvents }");
   });
 
+  it("includes configDir for monorepo support", () => {
+    const file = generateClientFile([], []);
+
+    // Should include Node imports for deriving configDir
+    expect(file).toContain('import { fileURLToPath } from "url"');
+    expect(file).toContain('import { dirname } from "path"');
+    // Should derive __configDir from import.meta.url
+    expect(file).toContain("const __configDir = dirname(fileURLToPath(import.meta.url))");
+    // Should pass configDir to createTinybirdClient
+    expect(file).toContain("configDir: __configDir");
+  });
+
   it("handles empty datasources and pipes", () => {
     const file = generateClientFile([], []);
 

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -268,6 +268,9 @@ export function generateClientFile(
     " */",
     "",
     'import { createTinybirdClient } from "@tinybirdco/sdk";',
+    // Node imports for deriving configDir from import.meta.url (monorepo support)
+    'import { fileURLToPath } from "url";',
+    'import { dirname } from "path";',
     "",
   ];
 
@@ -304,7 +307,11 @@ export function generateClientFile(
 
   lines.push("");
 
-  // Create client
+  // Create client with configDir for monorepo support
+  lines.push("// Derive configDir from import.meta.url for monorepo support");
+  lines.push("// This ensures tinybird.json is found regardless of where the app runs from");
+  lines.push("const __configDir = dirname(fileURLToPath(import.meta.url));");
+  lines.push("");
   lines.push("// Create the typed Tinybird client");
   lines.push("export const tinybird = createTinybirdClient({");
 
@@ -322,6 +329,7 @@ export function generateClientFile(
     lines.push("  pipes: {},");
   }
 
+  lines.push("  configDir: __configDir,");
   lines.push("});");
   lines.push("");
 
@@ -445,6 +453,9 @@ export function generateCombinedFile(
   lines.push(`import {`);
   lines.push(`  ${sdkImports.join(",\n  ")},`);
   lines.push(`} from "@tinybirdco/sdk";`);
+  // Node imports for deriving configDir from import.meta.url (monorepo support)
+  lines.push('import { fileURLToPath } from "url";');
+  lines.push('import { dirname } from "path";');
   lines.push("");
 
   // Datasources section
@@ -489,9 +500,15 @@ export function generateCombinedFile(
       ? endpoints.map((p) => toCamelCase(p.name)).join(", ")
       : "";
 
+  // Derive configDir from import.meta.url for monorepo support
+  lines.push("// Derive configDir from import.meta.url for monorepo support");
+  lines.push("// This ensures tinybird.json is found regardless of where the app runs from");
+  lines.push("const __configDir = dirname(fileURLToPath(import.meta.url));");
+  lines.push("");
   lines.push("export const tinybird = createTinybirdClient({");
   lines.push(`  datasources: { ${dsNames} },`);
   lines.push(`  pipes: { ${pipeNames} },`);
+  lines.push("  configDir: __configDir,");
   lines.push("});");
   lines.push("");
 

--- a/src/generator/client.ts
+++ b/src/generator/client.ts
@@ -110,6 +110,9 @@ export function generateClientFile(options: GenerateClientOptions): GeneratedCli
   importLines.push(
     `import { createTinybirdClient, type ${sdkTypes.join(", type ")} } from "@tinybirdco/sdk";`
   );
+  // Node imports for deriving configDir from import.meta.url (monorepo support)
+  importLines.push(`import { fileURLToPath } from "url";`);
+  importLines.push(`import { dirname } from "path";`);
   importLines.push("");
 
   // Entity imports and re-exports
@@ -129,6 +132,10 @@ export function generateClientFile(options: GenerateClientOptions): GeneratedCli
   const pipeNames = Object.keys(entities.pipes);
 
   const clientLines: string[] = [];
+  // Derive configDir from import.meta.url for monorepo support
+  // This ensures tinybird.json is found regardless of where the app runs from
+  clientLines.push("const __configDir = dirname(fileURLToPath(import.meta.url));");
+  clientLines.push("");
   clientLines.push("export const tinybird = createTinybirdClient({");
 
   if (datasourceNames.length > 0) {
@@ -143,6 +150,7 @@ export function generateClientFile(options: GenerateClientOptions): GeneratedCli
     clientLines.push("  pipes: {},");
   }
 
+  clientLines.push("  configDir: __configDir,");
   clientLines.push("});");
 
   // Build type exports

--- a/src/schema/project.ts
+++ b/src/schema/project.ts
@@ -101,6 +101,12 @@ export interface TinybirdClientConfig<
   baseUrl?: string;
   /** Tinybird API token (defaults to TINYBIRD_TOKEN env var) */
   token?: string;
+  /**
+   * Directory to use as the starting point when searching for tinybird.json config.
+   * In monorepo setups, this should be set to the directory containing tinybird.json
+   * to ensure the config is found regardless of where the application runs from.
+   */
+  configDir?: string;
 }
 
 /**
@@ -215,7 +221,7 @@ function buildProjectClient<
 >(
   datasources: TDatasources,
   pipes: TPipes,
-  options?: { baseUrl?: string; token?: string }
+  options?: { baseUrl?: string; token?: string; configDir?: string }
 ): ProjectClient<TDatasources, TPipes> {
   // Lazy client initialization
   let _client: TinybirdClient | null = null;
@@ -234,6 +240,7 @@ function buildProjectClient<
         baseUrl,
         token,
         devMode: process.env.NODE_ENV === "development",
+        configDir: options?.configDir,
       });
     }
     return _client;
@@ -342,7 +349,7 @@ export function createTinybirdClient<
   return buildProjectClient(
     config.datasources,
     config.pipes,
-    { baseUrl: config.baseUrl, token: config.token }
+    { baseUrl: config.baseUrl, token: config.token, configDir: config.configDir }
   );
 }
 


### PR DESCRIPTION
## Summary

- Fixes config file resolution in monorepo setups where the SDK client is used from a different package than where `tinybird.json` lives
- The generated client now derives `configDir` from `import.meta.url` to always find the config relative to the client file, not `process.cwd()`
- Adds `configDir` option to `ClientConfig` and `TinybirdClientConfig` for custom configuration

## Problem

In a monorepo setup like:
```
monorepo/
├── packages/
│   ├── @myorg/tinybird/
│   │   ├── tinybird.json
│   │   └── lib/client.ts (generated)
│   └── @myorg/api/
│       └── index.ts (imports from @myorg/tinybird)
```

When running from `@myorg/api`, `loadConfig()` was using `process.cwd()` which would fail to find `tinybird.json` in the sibling package.

## Solution

The generated client now includes:
```typescript
import { fileURLToPath } from "url";
import { dirname } from "path";

const __configDir = dirname(fileURLToPath(import.meta.url));

export const tinybird = createTinybirdClient({
  datasources: { ... },
  pipes: { ... },
  configDir: __configDir,
});
```

## Test plan

- [x] All existing tests pass (693 tests)
- [x] Added test for `configDir` in generated client
- [ ] Manual testing in a monorepo setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)