### PR TITLE
fix: support trunk-based development in local mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybirdco/sdk",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "TypeScript SDK for Tinybird Forward - define datasources and pipes as TypeScript",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Fixes local mode failing with 400 error when on main branch (trunk-based development)
- When in local mode on main branch, now uses the authenticated workspace name from the cloud token instead of "main"
- Bumps version to 0.0.28

## Problem

Users doing trunk-based development (working directly on main) face an issue when using `devMode: "local"`. The CLI tries to create a workspace named "main" which the local container rejects with a 400 error.

## Solution

When in local mode AND on main branch (or no branch), use the authenticated workspace name from the cloud token instead of the git branch name. The `getWorkspace()` API already exists and returns the workspace name.

Fixes https://github.com/tinybirdco/tinybird-sdk-typescript/issues/45

## Test plan

- [x] All existing tests pass (712 tests)
- [ ] Test on main branch with `devMode: "local"` - should succeed using authenticated workspace name
- [ ] Test on feature branch with `devMode: "local"` - behavior unchanged (uses branch name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)