### PR TITLE
fix(ci): build SDK before MCP in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build SDK (required by MCP)
+        run: pnpm run build
+
       - name: Build MCP
         run: pnpm --filter @tinybirdco/devtools-mcp build
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybirdco/sdk",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "description": "TypeScript SDK for Tinybird Forward - define datasources and pipes as TypeScript",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Fix publish workflow by building SDK before MCP package
- The MCP package imports from `@tinybirdco/sdk/cli/commands/login` and `@tinybirdco/sdk/cli/commands/build` subpath exports, which require the SDK dist files to exist
- Bump SDK version to 0.0.29

## Test plan
- [ ] Verify CI workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)