### PR TITLE
feat: add open command to CLI and MCP

### DIFF
--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -14,6 +14,7 @@ import { registerListBranchesTool } from "./tools/list-branches.js";
 import { registerLoginTool } from "./tools/login.js";
 import { registerBuildTool } from "./tools/build.js";
 import { registerInfoTool } from "./tools/info.js";
+import { registerOpenDashboardTool } from "./tools/open-dashboard.js";
 import pkg from "../package.json" with { type: "json" }
 
 /**
@@ -44,6 +45,7 @@ export function createMcpServer(): McpServer {
   registerLoginTool(server, config);
   registerBuildTool(server, config);
   registerInfoTool(server, config);
+  registerOpenDashboardTool(server, config);
 
   return server;
 }

--- a/mcp/src/tools/open-dashboard.ts
+++ b/mcp/src/tools/open-dashboard.ts
@@ -1,0 +1,105 @@
+/**
+ * Open Dashboard Tool
+ * Opens the Tinybird dashboard in the default browser
+ */
+
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ResolvedConfig } from "../config.js";
+
+/**
+ * Register the open_dashboard tool
+ */
+export function registerOpenDashboardTool(
+  server: McpServer,
+  _config: ResolvedConfig
+): void {
+  server.tool(
+    "open_dashboard",
+    "Open the Tinybird dashboard in the default browser. Opens the dashboard for the specified environment (cloud, local, or branch).",
+    {
+      cwd: z
+        .string()
+        .optional()
+        .describe(
+          "Working directory containing tinybird.json (defaults to process.cwd())"
+        ),
+      env: z
+        .enum(["cloud", "local", "branch"])
+        .describe(
+          "Which environment to open: 'cloud' (main workspace), 'local' (localhost), or 'branch' (development branch)"
+        ),
+    },
+    async ({ cwd, env }) => {
+      const workingDir = cwd ?? process.cwd();
+
+      try {
+        const { runOpenDashboard } = await import(
+          "@tinybirdco/sdk/cli/commands/open-dashboard"
+        );
+
+        const result = await runOpenDashboard({
+          cwd: workingDir,
+          environment: env,
+        });
+
+        if (!result.success) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify(
+                  {
+                    success: false,
+                    error: result.error,
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  success: true,
+                  url: result.url,
+                  environment: result.environment,
+                  browserOpened: result.browserOpened,
+                  message: result.browserOpened
+                    ? `Opened ${result.environment} dashboard in browser`
+                    : `Dashboard URL: ${result.url} (browser may not have opened)`,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  success: false,
+                  error: (error as Error).message,
+                },
+                null,
+                2
+              ),
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybirdco/sdk",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "TypeScript SDK for Tinybird Forward - define datasources and pipes as TypeScript",
   "type": "module",
   "main": "./dist/index.js",
@@ -33,6 +33,10 @@
     "./api/workspaces": {
       "import": "./dist/api/workspaces.js",
       "types": "./dist/api/workspaces.d.ts"
+    },
+    "./cli/commands/open-dashboard": {
+      "import": "./dist/cli/commands/open-dashboard.js",
+      "types": "./dist/cli/commands/open-dashboard.d.ts"
     }
   },
   "files": [

--- a/src/cli/commands/open-dashboard.test.ts
+++ b/src/cli/commands/open-dashboard.test.ts
@@ -1,0 +1,472 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { runOpenDashboard } from "./open-dashboard.js";
+
+// Mock the config module
+vi.mock("../config.js", () => ({
+  loadConfig: vi.fn(),
+}));
+
+// Mock the API modules
+vi.mock("../../api/workspaces.js", () => ({
+  getWorkspace: vi.fn(),
+}));
+
+vi.mock("../../api/branches.js", () => ({
+  getBranch: vi.fn(),
+}));
+
+vi.mock("../../api/dashboard.js", () => ({
+  getDashboardUrl: vi.fn(),
+  getBranchDashboardUrl: vi.fn(),
+  getLocalDashboardUrl: vi.fn(),
+}));
+
+vi.mock("../../api/local.js", () => ({
+  isLocalRunning: vi.fn(),
+  getLocalTokens: vi.fn(),
+  getOrCreateLocalWorkspace: vi.fn(),
+  getLocalWorkspaceName: vi.fn(),
+}));
+
+vi.mock("../auth.js", () => ({
+  openBrowser: vi.fn(),
+}));
+
+// Import mocked functions
+import { loadConfig } from "../config.js";
+import { getWorkspace } from "../../api/workspaces.js";
+import { getBranch } from "../../api/branches.js";
+import {
+  getDashboardUrl,
+  getBranchDashboardUrl,
+  getLocalDashboardUrl,
+} from "../../api/dashboard.js";
+import {
+  isLocalRunning,
+  getLocalTokens,
+  getOrCreateLocalWorkspace,
+  getLocalWorkspaceName,
+} from "../../api/local.js";
+import { openBrowser } from "../auth.js";
+
+const mockedLoadConfig = vi.mocked(loadConfig);
+const mockedGetWorkspace = vi.mocked(getWorkspace);
+const mockedGetBranch = vi.mocked(getBranch);
+const mockedGetDashboardUrl = vi.mocked(getDashboardUrl);
+const mockedGetBranchDashboardUrl = vi.mocked(getBranchDashboardUrl);
+const mockedGetLocalDashboardUrl = vi.mocked(getLocalDashboardUrl);
+const mockedIsLocalRunning = vi.mocked(isLocalRunning);
+const mockedGetLocalTokens = vi.mocked(getLocalTokens);
+const mockedGetOrCreateLocalWorkspace = vi.mocked(getOrCreateLocalWorkspace);
+const mockedGetLocalWorkspaceName = vi.mocked(getLocalWorkspaceName);
+const mockedOpenBrowser = vi.mocked(openBrowser);
+
+describe("Open Dashboard Command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedOpenBrowser.mockResolvedValue(true);
+  });
+
+  describe("config loading", () => {
+    it("returns error when config loading fails", async () => {
+      mockedLoadConfig.mockImplementation(() => {
+        throw new Error("No tinybird.json found");
+      });
+
+      const result = await runOpenDashboard();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("No tinybird.json found");
+    });
+  });
+
+  describe("cloud environment", () => {
+    const mockConfig = {
+      cwd: "/test/project",
+      configPath: "/test/project/tinybird.json",
+      devMode: "branch" as const,
+      gitBranch: "main",
+      tinybirdBranch: null,
+      isMainBranch: true,
+      baseUrl: "https://api.tinybird.co",
+      token: "test-token",
+      include: [],
+    };
+
+    const mockWorkspace = {
+      id: "ws-123",
+      name: "test-workspace",
+      user_email: "user@example.com",
+      user_id: "user-123",
+      scope: "WORKSPACE",
+      main: null,
+    };
+
+    beforeEach(() => {
+      mockedLoadConfig.mockReturnValue(mockConfig);
+      mockedGetWorkspace.mockResolvedValue(mockWorkspace);
+      mockedGetDashboardUrl.mockReturnValue(
+        "https://cloud.tinybird.co/gcp/europe-west3/test-workspace"
+      );
+    });
+
+    it("opens cloud dashboard when environment is cloud", async () => {
+      const result = await runOpenDashboard({ environment: "cloud" });
+
+      expect(result.success).toBe(true);
+      expect(result.environment).toBe("cloud");
+      expect(result.url).toBe(
+        "https://cloud.tinybird.co/gcp/europe-west3/test-workspace"
+      );
+      expect(result.browserOpened).toBe(true);
+      expect(mockedOpenBrowser).toHaveBeenCalledWith(
+        "https://cloud.tinybird.co/gcp/europe-west3/test-workspace"
+      );
+    });
+
+    it("defaults to cloud when devMode is branch and on main branch", async () => {
+      const result = await runOpenDashboard();
+
+      expect(result.success).toBe(true);
+      expect(result.environment).toBe("cloud");
+    });
+  });
+
+  describe("branch environment", () => {
+    const mockConfig = {
+      cwd: "/test/project",
+      configPath: "/test/project/tinybird.json",
+      devMode: "branch" as const,
+      gitBranch: "feature/test",
+      tinybirdBranch: "feature_test",
+      isMainBranch: false,
+      baseUrl: "https://api.tinybird.co",
+      token: "test-token",
+      include: [],
+    };
+
+    const mockWorkspace = {
+      id: "ws-123",
+      name: "test-workspace",
+      user_email: "user@example.com",
+      user_id: "user-123",
+      scope: "WORKSPACE",
+      main: null,
+    };
+
+    beforeEach(() => {
+      mockedLoadConfig.mockReturnValue(mockConfig);
+      mockedGetWorkspace.mockResolvedValue(mockWorkspace);
+    });
+
+    it("opens branch dashboard when environment is branch", async () => {
+      const mockBranch = {
+        id: "branch-123",
+        name: "feature_test",
+        token: "branch-token",
+        created_at: "2024-01-01",
+      };
+      mockedGetBranch.mockResolvedValue(mockBranch);
+      mockedGetBranchDashboardUrl.mockReturnValue(
+        "https://cloud.tinybird.co/gcp/europe-west3/test-workspace~feature_test"
+      );
+
+      const result = await runOpenDashboard({ environment: "branch" });
+
+      expect(result.success).toBe(true);
+      expect(result.environment).toBe("branch");
+      expect(result.url).toBe(
+        "https://cloud.tinybird.co/gcp/europe-west3/test-workspace~feature_test"
+      );
+      expect(mockedGetBranch).toHaveBeenCalledWith(
+        { baseUrl: "https://api.tinybird.co", token: "test-token" },
+        "feature_test"
+      );
+    });
+
+    it("defaults to branch when devMode is branch and on feature branch", async () => {
+      const mockBranch = {
+        id: "branch-123",
+        name: "feature_test",
+        token: "branch-token",
+        created_at: "2024-01-01",
+      };
+      mockedGetBranch.mockResolvedValue(mockBranch);
+      mockedGetBranchDashboardUrl.mockReturnValue(
+        "https://cloud.tinybird.co/gcp/europe-west3/test-workspace~feature_test"
+      );
+
+      const result = await runOpenDashboard();
+
+      expect(result.success).toBe(true);
+      expect(result.environment).toBe("branch");
+    });
+
+    it("returns error when trying to open branch on main", async () => {
+      mockedLoadConfig.mockReturnValue({
+        ...mockConfig,
+        gitBranch: "main",
+        tinybirdBranch: null,
+        isMainBranch: true,
+      });
+
+      const result = await runOpenDashboard({ environment: "branch" });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("not on a feature branch");
+    });
+
+    it("returns error when branch does not exist", async () => {
+      mockedGetBranch.mockRejectedValue(new Error("Branch not found"));
+
+      const result = await runOpenDashboard({ environment: "branch" });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("does not exist");
+      expect(result.error).toContain("tinybird build");
+    });
+  });
+
+  describe("local environment", () => {
+    const mockConfig = {
+      cwd: "/test/project",
+      configPath: "/test/project/tinybird.json",
+      devMode: "local" as const,
+      gitBranch: "feature/test",
+      tinybirdBranch: "feature_test",
+      isMainBranch: false,
+      baseUrl: "https://api.tinybird.co",
+      token: "test-token",
+      include: [],
+    };
+
+    const mockWorkspace = {
+      id: "ws-123",
+      name: "test-workspace",
+      user_email: "user@example.com",
+      user_id: "user-123",
+      scope: "WORKSPACE",
+      main: null,
+    };
+
+    beforeEach(() => {
+      mockedLoadConfig.mockReturnValue(mockConfig);
+      mockedGetWorkspace.mockResolvedValue(mockWorkspace);
+    });
+
+    it("opens local dashboard when environment is local and local is running", async () => {
+      mockedIsLocalRunning.mockResolvedValue(true);
+      mockedGetLocalTokens.mockResolvedValue({
+        user_token: "local-user-token",
+        admin_token: "local-admin-token",
+        workspace_admin_token: "local-ws-admin-token",
+      });
+      mockedGetLocalWorkspaceName.mockReturnValue("feature_test");
+      mockedGetOrCreateLocalWorkspace.mockResolvedValue({
+        workspace: {
+          id: "local-ws-123",
+          name: "feature_test",
+          token: "local-token",
+        },
+        wasCreated: false,
+      });
+      mockedGetLocalDashboardUrl.mockReturnValue(
+        "https://cloud.tinybird.co/local/7181/feature_test"
+      );
+
+      const result = await runOpenDashboard({ environment: "local" });
+
+      expect(result.success).toBe(true);
+      expect(result.environment).toBe("local");
+      expect(result.url).toBe(
+        "https://cloud.tinybird.co/local/7181/feature_test"
+      );
+    });
+
+    it("defaults to local when devMode is local", async () => {
+      mockedIsLocalRunning.mockResolvedValue(true);
+      mockedGetLocalTokens.mockResolvedValue({
+        user_token: "local-user-token",
+        admin_token: "local-admin-token",
+        workspace_admin_token: "local-ws-admin-token",
+      });
+      mockedGetLocalWorkspaceName.mockReturnValue("feature_test");
+      mockedGetOrCreateLocalWorkspace.mockResolvedValue({
+        workspace: {
+          id: "local-ws-123",
+          name: "feature_test",
+          token: "local-token",
+        },
+        wasCreated: false,
+      });
+      mockedGetLocalDashboardUrl.mockReturnValue(
+        "https://cloud.tinybird.co/local/7181/feature_test"
+      );
+
+      const result = await runOpenDashboard();
+
+      expect(result.success).toBe(true);
+      expect(result.environment).toBe("local");
+    });
+
+    it("returns error when local is not running", async () => {
+      mockedIsLocalRunning.mockResolvedValue(false);
+
+      const result = await runOpenDashboard({ environment: "local" });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("not running");
+      expect(result.error).toContain("docker run");
+    });
+
+    it("uses workspace name on main branch for local", async () => {
+      mockedLoadConfig.mockReturnValue({
+        ...mockConfig,
+        gitBranch: "main",
+        tinybirdBranch: null,
+        isMainBranch: true,
+      });
+      mockedIsLocalRunning.mockResolvedValue(true);
+      mockedGetLocalTokens.mockResolvedValue({
+        user_token: "local-user-token",
+        admin_token: "local-admin-token",
+        workspace_admin_token: "local-ws-admin-token",
+      });
+      mockedGetOrCreateLocalWorkspace.mockResolvedValue({
+        workspace: {
+          id: "local-ws-123",
+          name: "test-workspace",
+          token: "local-token",
+        },
+        wasCreated: false,
+      });
+      mockedGetLocalDashboardUrl.mockReturnValue(
+        "https://cloud.tinybird.co/local/7181/test-workspace"
+      );
+
+      const result = await runOpenDashboard({ environment: "local" });
+
+      expect(result.success).toBe(true);
+      expect(mockedGetOrCreateLocalWorkspace).toHaveBeenCalledWith(
+        expect.anything(),
+        "test-workspace"
+      );
+    });
+  });
+
+  describe("error handling", () => {
+    it("returns error when workspace fetch fails", async () => {
+      mockedLoadConfig.mockReturnValue({
+        cwd: "/test",
+        configPath: "/test/tinybird.json",
+        devMode: "branch" as const,
+        gitBranch: null,
+        tinybirdBranch: null,
+        isMainBranch: true,
+        baseUrl: "https://api.tinybird.co",
+        token: "test-token",
+        include: [],
+      });
+      mockedGetWorkspace.mockRejectedValue(new Error("Unauthorized"));
+
+      const result = await runOpenDashboard({ environment: "cloud" });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Failed to get workspace info");
+      expect(result.error).toContain("Unauthorized");
+    });
+
+    it("returns error when dashboard URL cannot be generated", async () => {
+      mockedLoadConfig.mockReturnValue({
+        cwd: "/test",
+        configPath: "/test/tinybird.json",
+        devMode: "branch" as const,
+        gitBranch: null,
+        tinybirdBranch: null,
+        isMainBranch: true,
+        baseUrl: "https://api.tinybird.co",
+        token: "test-token",
+        include: [],
+      });
+      mockedGetWorkspace.mockResolvedValue({
+        id: "ws-123",
+        name: "test-workspace",
+        user_email: "user@example.com",
+        user_id: "user-123",
+        scope: "WORKSPACE",
+        main: null,
+      });
+      mockedGetDashboardUrl.mockReturnValue(null);
+
+      const result = await runOpenDashboard({ environment: "cloud" });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Could not generate dashboard URL");
+    });
+
+    it("handles local workspace fetch error", async () => {
+      mockedLoadConfig.mockReturnValue({
+        cwd: "/test",
+        configPath: "/test/tinybird.json",
+        devMode: "local" as const,
+        gitBranch: "feature/test",
+        tinybirdBranch: "feature_test",
+        isMainBranch: false,
+        baseUrl: "https://api.tinybird.co",
+        token: "test-token",
+        include: [],
+      });
+      mockedGetWorkspace.mockResolvedValue({
+        id: "ws-123",
+        name: "test-workspace",
+        user_email: "user@example.com",
+        user_id: "user-123",
+        scope: "WORKSPACE",
+        main: null,
+      });
+      mockedIsLocalRunning.mockResolvedValue(true);
+      mockedGetLocalTokens.mockRejectedValue(new Error("Connection refused"));
+
+      const result = await runOpenDashboard({ environment: "local" });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Failed to get local workspace");
+    });
+  });
+
+  describe("browser opening", () => {
+    it("reports when browser failed to open", async () => {
+      mockedLoadConfig.mockReturnValue({
+        cwd: "/test",
+        configPath: "/test/tinybird.json",
+        devMode: "branch" as const,
+        gitBranch: null,
+        tinybirdBranch: null,
+        isMainBranch: true,
+        baseUrl: "https://api.tinybird.co",
+        token: "test-token",
+        include: [],
+      });
+      mockedGetWorkspace.mockResolvedValue({
+        id: "ws-123",
+        name: "test-workspace",
+        user_email: "user@example.com",
+        user_id: "user-123",
+        scope: "WORKSPACE",
+        main: null,
+      });
+      mockedGetDashboardUrl.mockReturnValue(
+        "https://cloud.tinybird.co/gcp/europe-west3/test-workspace"
+      );
+      mockedOpenBrowser.mockResolvedValue(false);
+
+      const result = await runOpenDashboard({ environment: "cloud" });
+
+      expect(result.success).toBe(true);
+      expect(result.browserOpened).toBe(false);
+      expect(result.url).toBe(
+        "https://cloud.tinybird.co/gcp/europe-west3/test-workspace"
+      );
+    });
+  });
+});

--- a/src/cli/commands/open-dashboard.ts
+++ b/src/cli/commands/open-dashboard.ts
@@ -1,0 +1,177 @@
+/**
+ * Open Dashboard command - opens the Tinybird dashboard in the default browser
+ */
+
+import { loadConfig, type ResolvedConfig } from "../config.js";
+import { getWorkspace } from "../../api/workspaces.js";
+import { getBranch } from "../../api/branches.js";
+import {
+  getDashboardUrl,
+  getBranchDashboardUrl,
+  getLocalDashboardUrl,
+} from "../../api/dashboard.js";
+import {
+  isLocalRunning,
+  getLocalTokens,
+  getOrCreateLocalWorkspace,
+  getLocalWorkspaceName,
+} from "../../api/local.js";
+import { openBrowser } from "../auth.js";
+
+/**
+ * Environment options for opening dashboard
+ */
+export type Environment = "cloud" | "local" | "branch";
+
+/**
+ * Open dashboard command options
+ */
+export interface OpenDashboardCommandOptions {
+  /** Working directory (defaults to cwd) */
+  cwd?: string;
+  /** Which environment to open: "cloud", "local", or "branch" */
+  environment?: Environment;
+}
+
+/**
+ * Result of the open dashboard command
+ */
+export interface OpenDashboardCommandResult {
+  /** Whether the operation was successful */
+  success: boolean;
+  /** The URL that was opened */
+  url?: string;
+  /** Which environment was opened */
+  environment?: Environment;
+  /** Whether the browser was opened */
+  browserOpened?: boolean;
+  /** Error message if failed */
+  error?: string;
+}
+
+/**
+ * Run the open dashboard command
+ *
+ * @param options - Command options
+ * @returns Result with URL and status
+ */
+export async function runOpenDashboard(
+  options: OpenDashboardCommandOptions = {}
+): Promise<OpenDashboardCommandResult> {
+  const cwd = options.cwd ?? process.cwd();
+
+  // Load config
+  let config: ResolvedConfig;
+  try {
+    config = loadConfig(cwd);
+  } catch (error) {
+    return {
+      success: false,
+      error: (error as Error).message,
+    };
+  }
+
+  // Determine environment: use option if provided, otherwise use devMode from config
+  // When devMode is "branch" but on main branch, default to "cloud"
+  let environment: Environment;
+  if (options.environment) {
+    environment = options.environment;
+  } else if (config.devMode === "local") {
+    environment = "local";
+  } else if (config.devMode === "branch" && !config.isMainBranch && config.tinybirdBranch) {
+    environment = "branch";
+  } else {
+    environment = "cloud";
+  }
+
+  // Get workspace info (needed for all dashboard URLs)
+  let workspace;
+  try {
+    workspace = await getWorkspace({
+      baseUrl: config.baseUrl,
+      token: config.token,
+    });
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed to get workspace info: ${(error as Error).message}`,
+    };
+  }
+
+  let url: string | null = null;
+
+  if (environment === "local") {
+    // Open local dashboard
+    const localRunning = await isLocalRunning();
+    if (!localRunning) {
+      return {
+        success: false,
+        error:
+          "Tinybird local is not running. Start with: docker run -d -p 7181:7181 tinybirdco/tinybird-local",
+      };
+    }
+
+    try {
+      const tokens = await getLocalTokens();
+      // Determine workspace name: use authenticated workspace name on main branch,
+      // otherwise use branch name (for trunk-based development support)
+      let workspaceName: string;
+      if (config.isMainBranch || !config.tinybirdBranch) {
+        workspaceName = workspace.name;
+      } else {
+        workspaceName = getLocalWorkspaceName(config.tinybirdBranch, config.cwd);
+      }
+      const { workspace: localWorkspace } = await getOrCreateLocalWorkspace(
+        tokens,
+        workspaceName
+      );
+      url = getLocalDashboardUrl(localWorkspace.name);
+    } catch (error) {
+      return {
+        success: false,
+        error: `Failed to get local workspace: ${(error as Error).message}`,
+      };
+    }
+  } else if (environment === "branch") {
+    // Open branch dashboard
+    if (config.isMainBranch || !config.tinybirdBranch) {
+      return {
+        success: false,
+        error: "Cannot open branch dashboard: not on a feature branch.",
+      };
+    }
+
+    try {
+      const branch = await getBranch(
+        { baseUrl: config.baseUrl, token: config.token },
+        config.tinybirdBranch
+      );
+      url = getBranchDashboardUrl(config.baseUrl, workspace.name, branch.name);
+    } catch (error) {
+      return {
+        success: false,
+        error: `Branch '${config.tinybirdBranch}' does not exist. Run 'tinybird build' to create it.`,
+      };
+    }
+  } else {
+    // Open cloud (main workspace) dashboard
+    url = getDashboardUrl(config.baseUrl, workspace.name);
+  }
+
+  if (!url) {
+    return {
+      success: false,
+      error: "Could not generate dashboard URL for this configuration.",
+    };
+  }
+
+  // Open the browser
+  const browserOpened = await openBrowser(url);
+
+  return {
+    success: true,
+    url,
+    environment,
+    browserOpened,
+  };
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -28,6 +28,7 @@ import {
 } from "./commands/branch.js";
 import { runClear } from "./commands/clear.js";
 import { runInfo } from "./commands/info.js";
+import { runOpenDashboard, type Environment } from "./commands/open-dashboard.js";
 import {
   detectPackageManagerInstallCmd,
   detectPackageManagerRunCmd,
@@ -202,6 +203,40 @@ function createCli(): Command {
           branch: result.branch,
           project: result.project,
         });
+      }
+    });
+
+  // Open command
+  program
+    .command("open")
+    .description("Open the Tinybird dashboard in the default browser")
+    .option(
+      "-e, --env <env>",
+      "Which environment to open: 'cloud', 'local', or 'branch'"
+    )
+    .action(async (options) => {
+      const validEnvs = ["cloud", "local", "branch"];
+      if (options.env && !validEnvs.includes(options.env)) {
+        console.error(
+          `Error: Invalid environment '${options.env}'. Use one of: ${validEnvs.join(", ")}`
+        );
+        process.exit(1);
+      }
+
+      const result = await runOpenDashboard({
+        environment: options.env as Environment | undefined,
+      });
+
+      if (!result.success) {
+        console.error(`Error: ${result.error}`);
+        process.exit(1);
+      }
+
+      console.log(`Opening ${result.environment} dashboard...`);
+      if (result.browserOpened) {
+        console.log(`Dashboard: ${result.url}`);
+      } else {
+        console.log(`Could not open browser. Please visit: ${result.url}`);
       }
     });
 


### PR DESCRIPTION
## Summary

- Add `tinybird open` CLI command to open dashboard in browser
- Add `open_dashboard` MCP tool with required `env` parameter
- Intelligent defaults based on devMode and git branch context

Closes #52

## Test plan

- [x] Unit tests pass (`pnpm test:run src/cli/commands/open-dashboard.test.ts`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual test: `tinybird open --env cloud`
- [ ] Manual test: `tinybird open --env local` (with local running)
- [ ] Manual test: `tinybird open --env branch` (on feature branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)