### PR TITLE
feat: add origin=ts-sdk param to browser login URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybirdco/sdk",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "TypeScript SDK for Tinybird Forward - define datasources and pipes as TypeScript",
   "type": "module",
   "main": "./dist/index.js",
@@ -69,7 +69,7 @@
     "commander": "^12.0.0",
     "dotenv": "^16.0.0",
     "esbuild": "^0.24.0",
-"picocolors": "^1.1.1",
+    "picocolors": "^1.1.1",
     "zod": "^3.25.0"
   },
   "devDependencies": {

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -321,6 +321,7 @@ export async function browserLogin(
     // Build auth URL
     const authUrl = new URL("/api/cli-login", authHost);
     authUrl.searchParams.set("apiHost", apiHost);
+    authUrl.searchParams.set("origin", "ts-sdk");
 
     console.log("Opening browser for authentication...");
 


### PR DESCRIPTION
## Summary
- Adds `origin=ts-sdk` query parameter to the authentication URL when opening the browser for login
- Allows Tinybird to track authentication requests coming from the TypeScript SDK
- Bumps version to 0.0.32

## Test plan
- [x] Run `npm test` - login and init tests pass
- [ ] Manual test: run `npx tinybird login` and verify URL contains `origin=ts-sdk`

🤖 Generated with [Claude Code](https://claude.com/claude-code)