### PR TITLE
feat: add origin=ts-sdk param to CLI callback redirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybirdco/sdk",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "TypeScript SDK for Tinybird Forward - define datasources and pipes as TypeScript",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Adds `origin=ts-sdk` parameter to the OAuth callback redirect URL so Tinybird can track logins from the TypeScript SDK
- Bumps version to 0.0.33

## Test plan
- [ ] Run `tinybird login` and verify the callback redirect includes `origin=ts-sdk` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)