### PR TITLE
feat: add SHARED_WITH support to datasource generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybirdco/sdk",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "description": "TypeScript SDK for Tinybird Forward - define datasources and pipes as TypeScript",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/generator/datasource.test.ts
+++ b/src/generator/datasource.test.ts
@@ -492,4 +492,48 @@ describe('Datasource Generator', () => {
       expect(result.content).toContain('TOKEN ref_token APPEND');
     });
   });
+
+  describe('Shared with configuration', () => {
+    it('generates SHARED_WITH for single workspace', () => {
+      const ds = defineDatasource('test_ds', {
+        schema: { id: t.string() },
+        sharedWith: ['other_workspace'],
+      });
+
+      const result = generateDatasource(ds);
+      expect(result.content).toContain('SHARED_WITH >');
+      expect(result.content).toContain('    other_workspace');
+    });
+
+    it('generates SHARED_WITH for multiple workspaces', () => {
+      const ds = defineDatasource('test_ds', {
+        schema: { id: t.string() },
+        sharedWith: ['workspace_a', 'workspace_b'],
+      });
+
+      const result = generateDatasource(ds);
+      expect(result.content).toContain('SHARED_WITH >');
+      expect(result.content).toContain('    workspace_a,');
+      expect(result.content).toContain('    workspace_b');
+    });
+
+    it('does not include SHARED_WITH when not provided', () => {
+      const ds = defineDatasource('test_ds', {
+        schema: { id: t.string() },
+      });
+
+      const result = generateDatasource(ds);
+      expect(result.content).not.toContain('SHARED_WITH');
+    });
+
+    it('does not include SHARED_WITH when empty array', () => {
+      const ds = defineDatasource('test_ds', {
+        schema: { id: t.string() },
+        sharedWith: [],
+      });
+
+      const result = generateDatasource(ds);
+      expect(result.content).not.toContain('SHARED_WITH');
+    });
+  });
 });

--- a/src/generator/datasource.ts
+++ b/src/generator/datasource.ts
@@ -181,6 +181,23 @@ function generateForwardQuery(forwardQuery?: string): string | null {
 }
 
 /**
+ * Generate SHARED_WITH section for sharing datasource with other workspaces
+ */
+function generateSharedWith(sharedWith?: readonly string[]): string | null {
+  if (!sharedWith || sharedWith.length === 0) {
+    return null;
+  }
+
+  const lines = ["SHARED_WITH >"];
+  sharedWith.forEach((workspace, index) => {
+    const suffix = index < sharedWith.length - 1 ? "," : "";
+    lines.push(`    ${workspace}${suffix}`);
+  });
+
+  return lines.join("\n");
+}
+
+/**
  * Generate TOKEN lines for a datasource
  */
 function generateTokens(tokens?: readonly TokenConfig[]): string[] {
@@ -278,6 +295,13 @@ export function generateDatasource(
   if (tokenLines.length > 0) {
     parts.push("");
     parts.push(tokenLines.join("\n"));
+  }
+
+  // Add shared_with if present
+  const sharedWithBlock = generateSharedWith(datasource.options.sharedWith);
+  if (sharedWithBlock) {
+    parts.push("");
+    parts.push(sharedWithBlock);
   }
 
   return {


### PR DESCRIPTION
## Summary

- Add `generateSharedWith()` function to generate the `SHARED_WITH` block for sharing datasources with other workspaces
- The `sharedWith` option was already defined in the type but the generator wasn't outputting it
- Bump version to 0.0.34

## Test plan

- [x] Added tests for single workspace, multiple workspaces, and empty/undefined cases
- [x] All 36 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #59