### PR TITLE
chore: bump version to 0.0.37

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybirdco/sdk",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "description": "TypeScript SDK for Tinybird Forward - define datasources and pipes as TypeScript",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bumps package version from 0.0.36 to 0.0.37 for the new datasources.append functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)