### PR TITLE
feat: support glob include patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ Create a `tinybird.config.json` (or `tinybird.config.mjs` / `tinybird.config.cjs
 ```
 
 You can mix TypeScript files with raw `.datasource` and `.pipe` files for incremental migration.
+`include` also supports glob patterns like `src/tinybird/**/*.ts` and `src/tinybird/**/*.datasource`.
 
 ### Config File Formats
 
@@ -451,7 +452,7 @@ export default {
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `include` | `string[]` | *required* | Array of TypeScript files or raw `.datasource`/`.pipe` files to include |
+| `include` | `string[]` | *required* | Array of file paths or glob patterns for TypeScript files and raw `.datasource`/`.pipe` files |
 | `token` | `string` | *required* | API token. Supports `${ENV_VAR}` interpolation for environment variables |
 | `baseUrl` | `string` | `"https://api.tinybird.co"` | Tinybird API URL. Use `"https://api.us-east.tinybird.co"` for US region |
 | `devMode` | `"branch"` \| `"local"` | `"branch"` | Development mode. `"branch"` uses Tinybird cloud with branches, `"local"` uses local Docker container |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybirdco/sdk",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "description": "TypeScript SDK for Tinybird Forward - define datasources and pipes as TypeScript",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli/config-types.ts
+++ b/src/cli/config-types.ts
@@ -16,7 +16,7 @@ export type DevMode = "branch" | "local";
  * Tinybird configuration file structure
  */
 export interface TinybirdConfig {
-  /** Array of TypeScript files to scan for datasources and pipes */
+  /** Array of file paths or glob patterns to scan for TypeScript/resources */
   include?: string[];
   /** @deprecated Use `include` instead. Path to the TypeScript schema entry point */
   schema?: string;

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -14,7 +14,7 @@ import type { DevMode, TinybirdConfig } from "./config-types.js";
  * Resolved configuration with all values expanded
  */
 export interface ResolvedConfig {
-  /** Array of TypeScript files to scan for datasources and pipes */
+  /** Array of file paths or glob patterns to scan for datasources and pipes */
   include: string[];
   /** Resolved API token (workspace main token) */
   token: string;

--- a/src/generator/include-paths.ts
+++ b/src/generator/include-paths.ts
@@ -1,0 +1,234 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export interface ResolvedIncludeFile {
+  sourcePath: string;
+  absolutePath: string;
+}
+
+const GLOB_SEGMENT_REGEX = /[*?[]/;
+const IGNORED_DIRECTORIES = new Set([".git", "node_modules"]);
+const SEGMENT_REGEX_CACHE = new Map<string, RegExp>();
+
+function hasGlobPattern(value: string): boolean {
+  return GLOB_SEGMENT_REGEX.test(value);
+}
+
+function normalizePath(value: string): string {
+  return value.replace(/\\/g, "/");
+}
+
+function splitAbsolutePath(filePath: string): { root: string; segments: string[] } {
+  const absolutePath = path.resolve(filePath);
+  const root = path.parse(absolutePath).root;
+  const relative = path.relative(root, absolutePath);
+
+  return {
+    root: normalizePath(root),
+    segments: normalizePath(relative).split("/").filter(Boolean),
+  };
+}
+
+function segmentMatcher(segment: string): RegExp {
+  const cached = SEGMENT_REGEX_CACHE.get(segment);
+  if (cached) {
+    return cached;
+  }
+
+  const escaped = segment
+    .replace(/[.+^${}()|\\]/g, "\\$&")
+    .replace(/\*/g, "[^/]*")
+    .replace(/\?/g, "[^/]");
+
+  const matcher = new RegExp(`^${escaped}$`);
+  SEGMENT_REGEX_CACHE.set(segment, matcher);
+  return matcher;
+}
+
+function matchSegment(patternSegment: string, valueSegment: string): boolean {
+  if (!hasGlobPattern(patternSegment)) {
+    return patternSegment === valueSegment;
+  }
+
+  return segmentMatcher(patternSegment).test(valueSegment);
+}
+
+function matchGlobSegments(
+  patternSegments: string[],
+  pathSegments: string[],
+  patternIndex: number,
+  pathIndex: number,
+  memo: Map<string, boolean>
+): boolean {
+  const key = `${patternIndex}:${pathIndex}`;
+  const cached = memo.get(key);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  if (patternIndex === patternSegments.length) {
+    const matches = pathIndex === pathSegments.length;
+    memo.set(key, matches);
+    return matches;
+  }
+
+  const patternSegment = patternSegments[patternIndex];
+  let matches = false;
+
+  if (patternSegment === "**") {
+    matches = matchGlobSegments(patternSegments, pathSegments, patternIndex + 1, pathIndex, memo);
+
+    if (!matches && pathIndex < pathSegments.length) {
+      matches = matchGlobSegments(patternSegments, pathSegments, patternIndex, pathIndex + 1, memo);
+    }
+  } else if (
+    pathIndex < pathSegments.length &&
+    matchSegment(patternSegment, pathSegments[pathIndex])
+  ) {
+    matches = matchGlobSegments(patternSegments, pathSegments, patternIndex + 1, pathIndex + 1, memo);
+  }
+
+  memo.set(key, matches);
+  return matches;
+}
+
+function matchGlobPath(absolutePattern: string, absolutePath: string): boolean {
+  const patternParts = splitAbsolutePath(absolutePattern);
+  const pathParts = splitAbsolutePath(absolutePath);
+
+  if (patternParts.root.toLowerCase() !== pathParts.root.toLowerCase()) {
+    return false;
+  }
+
+  return matchGlobSegments(
+    patternParts.segments,
+    pathParts.segments,
+    0,
+    0,
+    new Map<string, boolean>()
+  );
+}
+
+function getGlobRootDirectory(absolutePattern: string): string {
+  const { root, segments } = splitAbsolutePath(absolutePattern);
+  const firstGlobIndex = segments.findIndex((segment) => hasGlobPattern(segment));
+  const baseSegments =
+    firstGlobIndex === -1 ? segments : segments.slice(0, firstGlobIndex);
+
+  return path.join(root, ...baseSegments);
+}
+
+function collectFilesRecursive(directory: string, result: string[]): void {
+  const entries = fs.readdirSync(directory, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      if (IGNORED_DIRECTORIES.has(entry.name)) {
+        continue;
+      }
+
+      collectFilesRecursive(fullPath, result);
+      continue;
+    }
+
+    if (entry.isFile()) {
+      result.push(fullPath);
+    }
+  }
+}
+
+function expandGlobPattern(absolutePattern: string): string[] {
+  const rootDirectory = getGlobRootDirectory(absolutePattern);
+
+  if (!fs.existsSync(rootDirectory)) {
+    return [];
+  }
+
+  if (!fs.statSync(rootDirectory).isDirectory()) {
+    return [];
+  }
+
+  const files: string[] = [];
+  collectFilesRecursive(rootDirectory, files);
+
+  return files
+    .filter((filePath) => matchGlobPath(absolutePattern, filePath))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+export function resolveIncludeFiles(
+  includePaths: string[],
+  cwd: string
+): ResolvedIncludeFile[] {
+  const resolved: ResolvedIncludeFile[] = [];
+  const seen = new Set<string>();
+
+  for (const includePath of includePaths) {
+    const absoluteIncludePath = path.isAbsolute(includePath)
+      ? includePath
+      : path.resolve(cwd, includePath);
+
+    if (hasGlobPattern(includePath)) {
+      const matchedFiles = expandGlobPattern(absoluteIncludePath);
+
+      if (matchedFiles.length === 0) {
+        throw new Error(`Include pattern matched no files: ${includePath}`);
+      }
+
+      for (const matchedFile of matchedFiles) {
+        if (seen.has(matchedFile)) {
+          continue;
+        }
+
+        seen.add(matchedFile);
+        resolved.push({
+          sourcePath: path.isAbsolute(includePath)
+            ? matchedFile
+            : path.relative(cwd, matchedFile),
+          absolutePath: matchedFile,
+        });
+      }
+      continue;
+    }
+
+    if (!fs.existsSync(absoluteIncludePath)) {
+      throw new Error(`Include file not found: ${absoluteIncludePath}`);
+    }
+
+    if (seen.has(absoluteIncludePath)) {
+      continue;
+    }
+
+    seen.add(absoluteIncludePath);
+    resolved.push({
+      sourcePath: includePath,
+      absolutePath: absoluteIncludePath,
+    });
+  }
+
+  return resolved;
+}
+
+export function getIncludeWatchDirectories(
+  includePaths: string[],
+  cwd: string
+): string[] {
+  const watchDirs = new Set<string>();
+
+  for (const includePath of includePaths) {
+    const absoluteIncludePath = path.isAbsolute(includePath)
+      ? includePath
+      : path.resolve(cwd, includePath);
+
+    if (hasGlobPattern(includePath)) {
+      watchDirs.add(getGlobRootDirectory(absoluteIncludePath));
+      continue;
+    }
+
+    watchDirs.add(path.dirname(absoluteIncludePath));
+  }
+
+  return Array.from(watchDirs);
+}

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -122,7 +122,7 @@ export async function build(options: BuildOptions): Promise<BuildResult> {
  * Build options using include paths
  */
 export interface BuildFromIncludeOptions {
-  /** Array of file paths to scan for datasources and pipes */
+  /** Array of file paths or glob patterns to scan for datasources and pipes */
   includePaths: string[];
   /** Working directory (defaults to cwd) */
   cwd?: string;


### PR DESCRIPTION
## Summary
- add glob pattern support for config include paths (`*`, `?`, `**`)
- resolve include patterns for build and dev watch mode
- add tests for matching and non-matching patterns
- document include glob support and bump package version to `0.0.40`

Closes #76