### PR TITLE
Move ingest to datasource accessors

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ This watches your schema files and automatically syncs changes to Tinybird.
 import { tinybird, type PageViewsRow } from "@tinybird/client";
 
 // Type-safe data ingestion
-await tinybird.ingest.pageViews({
+await tinybird.pageViews.ingest({
   timestamp: new Date(),
   pathname: "/home",
   session_id: "abc123",
@@ -180,9 +180,24 @@ const result = await tinybird.topPages.query({
 ```typescript
 import { tinybird } from "@tinybird/client";
 
+// Datasource accessors support: ingest, append, replace, delete, truncate
+
+// Ingest one row as JSON
+await tinybird.pageViews.ingest({
+  timestamp: new Date(),
+  pathname: "/pricing",
+  session_id: "session_123",
+  country: "US",
+});
+
 // Import rows from a remote file
 await tinybird.pageViews.append({
   url: "https://example.com/page_views.csv",
+});
+
+// Replace all rows from a remote file
+await tinybird.pageViews.replace({
+  url: "https://example.com/page_views_full_snapshot.csv",
 });
 
 // Delete matching rows

--- a/example/src/app/api/track/route.ts
+++ b/example/src/app/api/track/route.ts
@@ -11,10 +11,10 @@ export async function POST(request: NextRequest) {
     const body = (await request.json()) as TrackRequest;
 
     if (body.type === "pageview") {
-      await tinybird.ingest.pageViews(body.data as PageViewsRow);
+      await tinybird.pageViews.ingest(body.data as PageViewsRow);
       return NextResponse.json({ success: true, type: "pageview" });
     } else if (body.type === "event") {
-      await tinybird.ingest.events(body.data as EventsRow);
+      await tinybird.events.ingest(body.data as EventsRow);
       return NextResponse.json({ success: true, type: "event" });
     } else {
       return NextResponse.json(

--- a/src/api/api.test.ts
+++ b/src/api/api.test.ts
@@ -382,6 +382,31 @@ describe("TinybirdApi", () => {
       expect(requestBody).toBe("url=https%3A%2F%2Fexample.com%2Fdata.csv");
     });
 
+    it("supports replace mode", async () => {
+      let modeParam: string | null = null;
+
+      server.use(
+        http.post(`${BASE_URL}/v0/datasources`, async ({ request }) => {
+          const url = new URL(request.url);
+          modeParam = url.searchParams.get("mode");
+          return HttpResponse.json({ successful_rows: 1, quarantined_rows: 0 });
+        })
+      );
+
+      const api = createTinybirdApi({
+        baseUrl: BASE_URL,
+        token: "p.default-token",
+      });
+
+      await api.appendDatasource(
+        "events",
+        { url: "https://example.com/data.csv" },
+        { mode: "replace" }
+      );
+
+      expect(modeParam).toBe("replace");
+    });
+
     it("detects ndjson format from URL extension", async () => {
       let formatParam: string | null = null;
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -50,6 +50,8 @@ export interface TinybirdApiIngestOptions extends IngestOptions {
 export interface TinybirdApiAppendOptions extends Omit<AppendOptions, 'url' | 'file'> {
   /** Optional token override for this request */
   token?: string;
+  /** Import mode */
+  mode?: "append" | "replace";
 }
 
 export interface TinybirdApiDeleteOptions extends Omit<DeleteOptions, 'deleteCondition'> {
@@ -331,7 +333,7 @@ export class TinybirdApi {
 
     const url = new URL("/v0/datasources", `${this.baseUrl}/`);
     url.searchParams.set("name", datasourceName);
-    url.searchParams.set("mode", "append");
+    url.searchParams.set("mode", apiOptions.mode ?? "append");
 
     // Auto-detect format from file/url extension
     const format = this.detectFormat(sourceUrl ?? filePath!);

--- a/src/client/base.test.ts
+++ b/src/client/base.test.ts
@@ -149,13 +149,15 @@ describe("TinybirdClient", () => {
       expect(client.datasources).toBeDefined();
     });
 
-    it("datasources namespace has append method", () => {
+    it("datasources namespace has ingest/append/replace/delete/truncate methods", () => {
       const client = createClient({
         baseUrl: "https://api.tinybird.co",
         token: "test-token",
       });
 
+      expect(typeof client.datasources.ingest).toBe("function");
       expect(typeof client.datasources.append).toBe("function");
+      expect(typeof client.datasources.replace).toBe("function");
       expect(typeof client.datasources.delete).toBe("function");
       expect(typeof client.datasources.truncate).toBe("function");
     });
@@ -168,7 +170,9 @@ describe("TinybirdClient", () => {
 
       const datasources: DatasourcesNamespace = client.datasources;
       expect(datasources).toBeDefined();
+      expect(typeof datasources.ingest).toBe("function");
       expect(typeof datasources.append).toBe("function");
+      expect(typeof datasources.replace).toBe("function");
       expect(typeof datasources.delete).toBe("function");
       expect(typeof datasources.truncate).toBe("function");
     });

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -290,8 +290,16 @@ export interface TruncateResult {
  * Datasources namespace interface for raw client
  */
 export interface DatasourcesNamespace {
+  /** Ingest a single event into a datasource */
+  ingest<T extends Record<string, unknown>>(
+    datasourceName: string,
+    event: T,
+    options?: IngestOptions
+  ): Promise<IngestResult>;
   /** Append data to a datasource from a URL or file */
   append(datasourceName: string, options: AppendOptions): Promise<AppendResult>;
+  /** Replace all datasource rows with data from a URL or file */
+  replace(datasourceName: string, options: AppendOptions): Promise<AppendResult>;
   /** Delete rows from a datasource using a SQL condition */
   delete(datasourceName: string, options: DeleteOptions): Promise<DeleteResult>;
   /** Truncate all rows from a datasource */

--- a/src/schema/project.test.ts
+++ b/src/schema/project.test.ts
@@ -70,7 +70,7 @@ describe("Project Schema", () => {
       expect(project.pipes.topEvents).toBe(topEvents);
     });
 
-    it("creates tinybird client with pipe accessors and ingest methods", () => {
+    it("creates tinybird client with pipe and datasource accessors", () => {
       const events = defineDatasource("events", {
         schema: { id: t.string() },
       });
@@ -86,15 +86,15 @@ describe("Project Schema", () => {
         pipes: { topEvents },
       });
 
-      expect(project.tinybird.ingest).toBeDefined();
       expect(typeof project.tinybird.topEvents.query).toBe("function");
-      expect(typeof project.tinybird.ingest.events).toBe("function");
-      expect(typeof project.tinybird.ingest.eventsBatch).toBe("function");
+      expect(typeof project.tinybird.events.ingest).toBe("function");
+      expect(typeof project.tinybird.events.append).toBe("function");
+      expect(typeof project.tinybird.events.replace).toBe("function");
       expect((project.tinybird as unknown as Record<string, unknown>).query).toBeUndefined();
       expect((project.tinybird as unknown as Record<string, unknown>).pipes).toBeUndefined();
     });
 
-    it("creates datasource accessors with append/delete/truncate methods", () => {
+    it("creates datasource accessors with ingest/append/replace/delete/truncate methods", () => {
       const events = defineDatasource("events", {
         schema: { timestamp: t.dateTime() },
       });
@@ -104,7 +104,9 @@ describe("Project Schema", () => {
       });
 
       expect(project.tinybird.events).toBeDefined();
+      expect(typeof project.tinybird.events.ingest).toBe("function");
       expect(typeof project.tinybird.events.append).toBe("function");
+      expect(typeof project.tinybird.events.replace).toBe("function");
       expect(typeof project.tinybird.events.delete).toBe("function");
       expect(typeof project.tinybird.events.truncate).toBe("function");
     });
@@ -123,8 +125,12 @@ describe("Project Schema", () => {
 
       expect(project.tinybird.events).toBeDefined();
       expect(project.tinybird.pageViews).toBeDefined();
+      expect(typeof project.tinybird.events.ingest).toBe("function");
+      expect(typeof project.tinybird.pageViews.ingest).toBe("function");
       expect(typeof project.tinybird.events.append).toBe("function");
       expect(typeof project.tinybird.pageViews.append).toBe("function");
+      expect(typeof project.tinybird.events.replace).toBe("function");
+      expect(typeof project.tinybird.pageViews.replace).toBe("function");
       expect(typeof project.tinybird.events.delete).toBe("function");
       expect(typeof project.tinybird.pageViews.delete).toBe("function");
       expect(typeof project.tinybird.events.truncate).toBe("function");
@@ -284,7 +290,7 @@ describe("Project Schema", () => {
       process.env.NODE_ENV = originalNodeEnv;
     });
 
-    it("creates a client with pipe accessors and ingest methods", () => {
+    it("creates a client with pipe and datasource accessors", () => {
       const events = defineDatasource("events", {
         schema: { id: t.string() },
       });
@@ -300,17 +306,17 @@ describe("Project Schema", () => {
         pipes: { topEvents },
       });
 
-      expect(client.ingest).toBeDefined();
       expect(client.sql).toBeDefined();
       expect(typeof client.topEvents.query).toBe("function");
-      expect(typeof client.ingest.events).toBe("function");
-      expect(typeof client.ingest.eventsBatch).toBe("function");
+      expect(typeof client.events.ingest).toBe("function");
+      expect(typeof client.events.append).toBe("function");
+      expect(typeof client.events.replace).toBe("function");
       expect(typeof client.sql).toBe("function");
       expect((client as unknown as Record<string, unknown>).query).toBeUndefined();
       expect((client as unknown as Record<string, unknown>).pipes).toBeUndefined();
     });
 
-    it("creates datasource accessors with append/delete/truncate methods", () => {
+    it("creates datasource accessors with ingest/append/replace/delete/truncate methods", () => {
       const events = defineDatasource("events", {
         schema: { id: t.string() },
       });
@@ -321,7 +327,9 @@ describe("Project Schema", () => {
       });
 
       expect(client.events).toBeDefined();
+      expect(typeof client.events.ingest).toBe("function");
       expect(typeof client.events.append).toBe("function");
+      expect(typeof client.events.replace).toBe("function");
       expect(typeof client.events.delete).toBe("function");
       expect(typeof client.events.truncate).toBe("function");
     });
@@ -341,8 +349,12 @@ describe("Project Schema", () => {
 
       expect(client.events).toBeDefined();
       expect(client.pageViews).toBeDefined();
+      expect(typeof client.events.ingest).toBe("function");
+      expect(typeof client.pageViews.ingest).toBe("function");
       expect(typeof client.events.append).toBe("function");
       expect(typeof client.pageViews.append).toBe("function");
+      expect(typeof client.events.replace).toBe("function");
+      expect(typeof client.pageViews.replace).toBe("function");
       expect(typeof client.events.delete).toBe("function");
       expect(typeof client.pageViews.delete).toBe("function");
       expect(typeof client.events.truncate).toBe("function");
@@ -361,7 +373,7 @@ describe("Project Schema", () => {
         devMode: true,
       });
 
-      expect(clientWithDevMode.ingest).toBeDefined();
+      expect(clientWithDevMode.events.ingest).toBeDefined();
 
       const clientWithoutDevMode = createTinybirdClient({
         datasources: { events },
@@ -369,7 +381,7 @@ describe("Project Schema", () => {
         devMode: false,
       });
 
-      expect(clientWithoutDevMode.ingest).toBeDefined();
+      expect(clientWithoutDevMode.events.ingest).toBeDefined();
     });
 
     it("accepts all configuration options", () => {
@@ -387,7 +399,7 @@ describe("Project Schema", () => {
         devMode: true,
       });
 
-      expect(client.ingest).toBeDefined();
+      expect(client.events.ingest).toBeDefined();
     });
 
     it("throws error when accessing underlying client before initialization", () => {


### PR DESCRIPTION
## Problem
`ingest` was unintentionally removed from datasource/table methods. The expected surface is:

- `tinybird.<table>.ingest|append|replace|truncate|delete`
- `client.datasources.ingest`

## API Changes
### Typed project client (`createTinybirdClient`)
- Added/kept datasource accessor methods per table:
  - `tinybird.<table>.ingest(...)`
  - `tinybird.<table>.append(...)`
  - `tinybird.<table>.replace(...)`
  - `tinybird.<table>.delete(...)`
  - `tinybird.<table>.truncate(...)`
- Removed project-level ingest namespace:
  - `tinybird.ingest.<table>(...)`
  - `tinybird.ingest.<table>Batch(...)`

### Raw client (`createClient`)
- Added:
  - `client.datasources.ingest(datasourceName, event, options?)`
  - `client.datasources.replace(datasourceName, options)`
- Existing methods remain:
  - `client.datasources.append(...)`
  - `client.datasources.delete(...)`
  - `client.datasources.truncate(...)`

## Implementation Summary
- Wired `replace` through API append endpoint via `mode=replace`.
- Updated project/client typings and runtime wiring for datasource-local ingest.
- Updated README and example usage to datasource-local ingest.
- Updated and extended tests (including explicit replace-mode coverage).

## Migration
Before:
```ts
await tinybird.ingest.pageViews(row)
```

After:
```ts
await tinybird.pageViews.ingest(row)
```

## Validation
- `pnpm -s typecheck`
- `pnpm -s vitest run src/schema/project.test.ts src/client/base.test.ts src/api/api.test.ts`
- Result: all passing (`67` tests)

Closes #78