### PR TITLE
feat(cli): add pull command for cloud datafiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,16 @@ tinybird deploy
 tinybird deploy --dry-run  # Preview without pushing
 ```
 
+### `tinybird pull`
+
+Download all cloud resources as native Tinybird datafiles (`.datasource`, `.pipe`, `.connection`).
+
+```bash
+tinybird pull
+tinybird pull --output-dir ./tinybird-datafiles
+tinybird pull --force  # Overwrite existing files
+```
+
 ### `tinybird login`
 
 Authenticate with Tinybird via browser. Use this to set up credentials for an existing project without reinitializing.

--- a/src/cli/commands/pull.test.ts
+++ b/src/cli/commands/pull.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { runPull } from "./pull.js";
+
+vi.mock("../config.js", () => ({
+  loadConfigAsync: vi.fn(),
+}));
+
+vi.mock("../../api/resources.js", () => ({
+  pullAllResourceFiles: vi.fn(),
+}));
+
+import { loadConfigAsync } from "../config.js";
+import { pullAllResourceFiles } from "../../api/resources.js";
+
+const mockedLoadConfigAsync = vi.mocked(loadConfigAsync);
+const mockedPullAllResourceFiles = vi.mocked(pullAllResourceFiles);
+
+describe("Pull Command", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "tinybird-pull-test-"));
+
+    mockedLoadConfigAsync.mockResolvedValue({
+      include: ["src/lib/tinybird.ts"],
+      token: "p.test-token",
+      baseUrl: "https://api.tinybird.co",
+      configPath: path.join(tempDir, "tinybird.config.json"),
+      cwd: tempDir,
+      gitBranch: "feature/pull",
+      tinybirdBranch: "feature_pull",
+      isMainBranch: false,
+      devMode: "branch",
+    });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+    vi.resetAllMocks();
+  });
+
+  it("writes pulled datasource, pipe, and connection files", async () => {
+    mockedPullAllResourceFiles.mockResolvedValue({
+      datasources: [
+        {
+          name: "events",
+          type: "datasource",
+          filename: "events.datasource",
+          content: "SCHEMA >\n    timestamp DateTime",
+        },
+      ],
+      pipes: [
+        {
+          name: "top_events",
+          type: "pipe",
+          filename: "top_events.pipe",
+          content: "NODE endpoint\nSQL >\n    SELECT 1",
+        },
+      ],
+      connections: [
+        {
+          name: "main_kafka",
+          type: "connection",
+          filename: "main_kafka.connection",
+          content: "TYPE kafka",
+        },
+      ],
+    });
+
+    const result = await runPull({ cwd: tempDir, outputDir: "pulled" });
+
+    expect(result.success).toBe(true);
+    expect(result.stats).toEqual({
+      datasources: 1,
+      pipes: 1,
+      connections: 1,
+      total: 3,
+    });
+
+    const outputPath = path.join(tempDir, "pulled");
+    await expect(fs.readFile(path.join(outputPath, "events.datasource"), "utf-8")).resolves.toContain(
+      "SCHEMA >"
+    );
+    await expect(fs.readFile(path.join(outputPath, "top_events.pipe"), "utf-8")).resolves.toContain(
+      "NODE endpoint"
+    );
+    await expect(
+      fs.readFile(path.join(outputPath, "main_kafka.connection"), "utf-8")
+    ).resolves.toContain("TYPE kafka");
+  });
+
+  it("returns error when a file exists and overwrite is disabled", async () => {
+    mockedPullAllResourceFiles.mockResolvedValue({
+      datasources: [
+        {
+          name: "events",
+          type: "datasource",
+          filename: "events.datasource",
+          content: "SCHEMA >\n    timestamp DateTime",
+        },
+      ],
+      pipes: [],
+      connections: [],
+    });
+
+    const outputPath = path.join(tempDir, "pulled");
+    await fs.mkdir(outputPath, { recursive: true });
+    await fs.writeFile(path.join(outputPath, "events.datasource"), "old", "utf-8");
+
+    const result = await runPull({
+      cwd: tempDir,
+      outputDir: "pulled",
+      overwrite: false,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("File already exists");
+  });
+
+  it("overwrites existing files when overwrite is enabled", async () => {
+    mockedPullAllResourceFiles.mockResolvedValue({
+      datasources: [
+        {
+          name: "events",
+          type: "datasource",
+          filename: "events.datasource",
+          content: "new-content",
+        },
+      ],
+      pipes: [],
+      connections: [],
+    });
+
+    const outputPath = path.join(tempDir, "pulled");
+    await fs.mkdir(outputPath, { recursive: true });
+    await fs.writeFile(path.join(outputPath, "events.datasource"), "old-content", "utf-8");
+
+    const result = await runPull({
+      cwd: tempDir,
+      outputDir: "pulled",
+      overwrite: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.files?.[0]?.status).toBe("overwritten");
+    await expect(fs.readFile(path.join(outputPath, "events.datasource"), "utf-8")).resolves.toBe(
+      "new-content"
+    );
+  });
+
+  it("returns error when config loading fails", async () => {
+    mockedLoadConfigAsync.mockRejectedValue(new Error("No config found"));
+
+    const result = await runPull({ cwd: tempDir });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("No config found");
+  });
+
+  it("returns error when pull API fails", async () => {
+    mockedPullAllResourceFiles.mockRejectedValue(new Error("Unauthorized"));
+
+    const result = await runPull({ cwd: tempDir });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Pull failed");
+    expect(result.error).toContain("Unauthorized");
+  });
+});

--- a/src/cli/commands/pull.ts
+++ b/src/cli/commands/pull.ts
@@ -1,0 +1,177 @@
+/**
+ * Pull command - downloads all cloud resources as Tinybird datafiles
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { loadConfigAsync } from "../config.js";
+import {
+  pullAllResourceFiles,
+  type PulledResourceFiles,
+  type ResourceFile,
+  type ResourceFileType,
+} from "../../api/resources.js";
+
+/**
+ * Pull command options
+ */
+export interface PullCommandOptions {
+  /** Working directory (defaults to cwd) */
+  cwd?: string;
+  /** Output directory for pulled files (defaults to current directory) */
+  outputDir?: string;
+  /** Whether to overwrite existing files (defaults to false) */
+  overwrite?: boolean;
+}
+
+/**
+ * Single file written by pull
+ */
+export interface PulledFileResult {
+  /** Resource name */
+  name: string;
+  /** Resource type */
+  type: ResourceFileType;
+  /** Filename written */
+  filename: string;
+  /** Absolute path written */
+  path: string;
+  /** Path relative to cwd */
+  relativePath: string;
+  /** Whether this file was newly created or overwritten */
+  status: "created" | "overwritten";
+}
+
+/**
+ * Pull command result
+ */
+export interface PullCommandResult {
+  /** Whether pull was successful */
+  success: boolean;
+  /** Output directory used */
+  outputDir?: string;
+  /** Files written */
+  files?: PulledFileResult[];
+  /** Pull statistics */
+  stats?: {
+    datasources: number;
+    pipes: number;
+    connections: number;
+    total: number;
+  };
+  /** Error message if failed */
+  error?: string;
+  /** Duration in milliseconds */
+  durationMs: number;
+}
+
+/**
+ * Convert grouped resources to a flat file list
+ */
+function flattenResources(resources: PulledResourceFiles): ResourceFile[] {
+  return [...resources.datasources, ...resources.pipes, ...resources.connections];
+}
+
+/**
+ * Pull all resources from Tinybird and write them as datafiles
+ */
+export async function runPull(
+  options: PullCommandOptions = {}
+): Promise<PullCommandResult> {
+  const startTime = Date.now();
+  const cwd = options.cwd ?? process.cwd();
+  const outputDir = path.resolve(cwd, options.outputDir ?? ".");
+  const overwrite = options.overwrite ?? false;
+
+  let config: Awaited<ReturnType<typeof loadConfigAsync>>;
+  try {
+    config = await loadConfigAsync(cwd);
+  } catch (error) {
+    return {
+      success: false,
+      error: (error as Error).message,
+      durationMs: Date.now() - startTime,
+    };
+  }
+
+  let pulled: PulledResourceFiles;
+  try {
+    pulled = await pullAllResourceFiles({
+      baseUrl: config.baseUrl,
+      token: config.token,
+    });
+  } catch (error) {
+    return {
+      success: false,
+      error: `Pull failed: ${(error as Error).message}`,
+      durationMs: Date.now() - startTime,
+    };
+  }
+
+  const allFiles = flattenResources(pulled).sort((a, b) =>
+    a.filename.localeCompare(b.filename)
+  );
+
+  try {
+    await fs.mkdir(outputDir, { recursive: true });
+
+    const writtenFiles: PulledFileResult[] = [];
+
+    for (const file of allFiles) {
+      const absolutePath = path.join(outputDir, file.filename);
+      let existed = false;
+
+      try {
+        await fs.access(absolutePath);
+        existed = true;
+      } catch {
+        existed = false;
+      }
+
+      await fs.writeFile(absolutePath, file.content, {
+        encoding: "utf-8",
+        flag: overwrite ? "w" : "wx",
+      });
+
+      writtenFiles.push({
+        name: file.name,
+        type: file.type,
+        filename: file.filename,
+        path: absolutePath,
+        relativePath: path.relative(cwd, absolutePath),
+        status: existed ? "overwritten" : "created",
+      });
+    }
+
+    return {
+      success: true,
+      outputDir,
+      files: writtenFiles,
+      stats: {
+        datasources: pulled.datasources.length,
+        pipes: pulled.pipes.length,
+        connections: pulled.connections.length,
+        total: writtenFiles.length,
+      },
+      durationMs: Date.now() - startTime,
+    };
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+
+    if (err.code === "EEXIST") {
+      return {
+        success: false,
+        error:
+          `File already exists: ${err.path ?? "unknown"}. ` +
+          "Use --force to overwrite existing files.",
+        durationMs: Date.now() - startTime,
+      };
+    }
+
+    return {
+      success: false,
+      error: `Failed to write files: ${(error as Error).message}`,
+      durationMs: Date.now() - startTime,
+    };
+  }
+}


### PR DESCRIPTION
This adds a new `tinybird pull` command that downloads all datasources, pipes, and connectors as native Tinybird datafiles. It introduces resource API helpers to list and fetch raw `.datasource`, `.pipe`, and `.connection` content with endpoint fallbacks. The PR also includes CLI wiring, documentation updates, and tests for both API and command behavior.

Closes #68 