### PR TITLE
fix(cli): persist TINYBIRD_URL during init/login

### DIFF
--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -17,11 +17,23 @@ vi.mock("../region-selector.js", () => ({
   }),
 }));
 
+import { browserLogin } from "../auth.js";
+import { selectRegion } from "../region-selector.js";
+
+const mockedBrowserLogin = vi.mocked(browserLogin);
+const mockedSelectRegion = vi.mocked(selectRegion);
+
 describe("Init Command", () => {
   let tempDir: string;
 
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "tinybird-init-test-"));
+    vi.clearAllMocks();
+    mockedSelectRegion.mockResolvedValue({
+      success: true,
+      apiHost: "https://api.tinybird.co",
+    });
+    mockedBrowserLogin.mockResolvedValue({ success: false });
   });
 
   afterEach(() => {
@@ -530,6 +542,62 @@ describe("Init Command", () => {
       expect(result.success).toBe(true);
       expect(result.installTools).toEqual(["skills", "syntax-highlighting"]);
       expect(result.installedTools).toBeUndefined();
+    });
+  });
+
+  describe("login flow", () => {
+    it("saves TINYBIRD_URL during init login", async () => {
+      mockedBrowserLogin.mockResolvedValue({
+        success: true,
+        token: "new-token-123",
+        baseUrl: "https://api.us-east.tinybird.co",
+        workspaceName: "test-workspace",
+      });
+
+      const result = await runInit({
+        cwd: tempDir,
+        skipLogin: false,
+        devMode: "branch",
+        clientPath: "lib/tinybird.ts",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.loggedIn).toBe(true);
+
+      const envContent = fs.readFileSync(
+        path.join(tempDir, ".env.local"),
+        "utf-8"
+      );
+      expect(envContent).toContain("TINYBIRD_TOKEN=new-token-123");
+      expect(envContent).toContain("TINYBIRD_URL=https://api.us-east.tinybird.co");
+    });
+
+    it("uses selected region as TINYBIRD_URL when auth response has no baseUrl", async () => {
+      mockedSelectRegion.mockResolvedValue({
+        success: true,
+        apiHost: "https://api.eu-west.tinybird.co",
+      });
+      mockedBrowserLogin.mockResolvedValue({
+        success: true,
+        token: "new-token-456",
+        workspaceName: "test-workspace",
+      });
+
+      const result = await runInit({
+        cwd: tempDir,
+        skipLogin: false,
+        devMode: "branch",
+        clientPath: "lib/tinybird.ts",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.loggedIn).toBe(true);
+
+      const envContent = fs.readFileSync(
+        path.join(tempDir, ".env.local"),
+        "utf-8"
+      );
+      expect(envContent).toContain("TINYBIRD_URL=https://api.eu-west.tinybird.co");
     });
   });
 });

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -16,7 +16,7 @@ import {
   type DevMode,
 } from "../config.js";
 import { browserLogin } from "../auth.js";
-import { saveTinybirdToken } from "../env.js";
+import { saveTinybirdBaseUrl, saveTinybirdToken } from "../env.js";
 import { selectRegion } from "../region-selector.js";
 import { getGitRoot } from "../git.js";
 import { fetchAllResources } from "../../api/resources.js";
@@ -999,6 +999,7 @@ export async function runInit(options: InitOptions = {}): Promise<InitResult> {
 
         // Update config with selected region's baseUrl
         const baseUrl = authResult.baseUrl ?? regionResult.apiHost;
+        saveTinybirdBaseUrl(cwd, baseUrl);
         const currentConfigPath = findExistingConfigPath(cwd);
         if (currentConfigPath && currentConfigPath.endsWith(".json")) {
           updateConfig(currentConfigPath, { baseUrl });

--- a/src/cli/commands/login.test.ts
+++ b/src/cli/commands/login.test.ts
@@ -161,7 +161,7 @@ describe("Login Command", () => {
       );
     });
 
-    it("creates .env.local with token", async () => {
+    it("creates .env.local with token and base URL", async () => {
       mockedBrowserLogin.mockResolvedValue({
         success: true,
         token: "new-token-123",
@@ -178,19 +178,20 @@ describe("Login Command", () => {
         "utf-8"
       );
       expect(envContent).toContain("TINYBIRD_TOKEN=new-token-123");
+      expect(envContent).toContain("TINYBIRD_URL=https://api.tinybird.co");
     });
 
     it("updates existing token in .env.local", async () => {
       // Create existing .env.local with old token
       fs.writeFileSync(
         path.join(tempDir, ".env.local"),
-        "TINYBIRD_TOKEN=old-token\nOTHER_VAR=value\n"
+        "TINYBIRD_TOKEN=old-token\nTINYBIRD_URL=https://old.tinybird.co\nOTHER_VAR=value\n"
       );
 
       mockedBrowserLogin.mockResolvedValue({
         success: true,
         token: "new-token-456",
-        baseUrl: "https://api.tinybird.co",
+        baseUrl: "https://api.us-east.tinybird.co",
         workspaceName: "test-workspace",
       });
 
@@ -203,8 +204,10 @@ describe("Login Command", () => {
         "utf-8"
       );
       expect(envContent).toContain("TINYBIRD_TOKEN=new-token-456");
+      expect(envContent).toContain("TINYBIRD_URL=https://api.us-east.tinybird.co");
       expect(envContent).toContain("OTHER_VAR=value");
       expect(envContent).not.toContain("old-token");
+      expect(envContent).not.toContain("https://old.tinybird.co");
     });
 
     it("appends token to existing .env.local without TINYBIRD_TOKEN", async () => {
@@ -231,6 +234,7 @@ describe("Login Command", () => {
       );
       expect(envContent).toContain("OTHER_VAR=value");
       expect(envContent).toContain("TINYBIRD_TOKEN=new-token-789");
+      expect(envContent).toContain("TINYBIRD_URL=https://api.tinybird.co");
     });
 
     it("saves .env.local in same directory as tinybird.json (monorepo)", async () => {
@@ -312,6 +316,12 @@ describe("Login Command", () => {
       );
       // Original baseUrl preserved
       expect(config.baseUrl).toBe("https://api.tinybird.co");
+
+      const envContent = fs.readFileSync(
+        path.join(tempDir, ".env.local"),
+        "utf-8"
+      );
+      expect(envContent).toContain("TINYBIRD_URL=https://api.tinybird.co");
     });
   });
 

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -5,7 +5,7 @@
 import * as path from "path";
 import { browserLogin, type LoginOptions, type AuthResult } from "../auth.js";
 import { updateConfig, findConfigFile } from "../config.js";
-import { saveTinybirdToken } from "../env.js";
+import { saveTinybirdBaseUrl, saveTinybirdToken } from "../env.js";
 import { getApiHostWithRegionSelection } from "../region-selector.js";
 
 /**
@@ -87,6 +87,8 @@ export async function runLogin(options: RunLoginOptions = {}): Promise<LoginResu
   // Save token to .env.local (in same directory as config file)
   try {
     saveTinybirdToken(configDir, authResult.token);
+    const baseUrl = authResult.baseUrl ?? apiHost;
+    saveTinybirdBaseUrl(configDir, baseUrl);
 
     // Update baseUrl in config file if it changed (only for JSON configs)
     if (authResult.baseUrl && configPath.endsWith(".json")) {


### PR DESCRIPTION
## Summary
- persist `TINYBIRD_URL` to `.env.local` during `tinybird login`
- persist `TINYBIRD_URL` to `.env.local` during `tinybird init` login flow
- keep existing config update behavior and use region/api host as fallback when auth response lacks `baseUrl`
- add regression tests for both command paths

## Testing
- `pnpm vitest run src/cli/commands/login.test.ts src/cli/commands/init.test.ts`
- `pnpm test:run`

Closes #93