### PR TITLE
fix: TS deploy error messaging for destructive operations (PRO-610)

### DIFF
--- a/src/cli/commands/deploy.test.ts
+++ b/src/cli/commands/deploy.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { runDeploy } from "./deploy.js";
+
+vi.mock("../config.js", () => ({
+  loadConfigAsync: vi.fn(),
+}));
+
+vi.mock("../../generator/index.js", () => ({
+  buildFromInclude: vi.fn(),
+}));
+
+vi.mock("../../api/deploy.js", () => ({
+  deployToMain: vi.fn(),
+}));
+
+describe("Deploy command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("passes allowDestructiveOperations to deployToMain", async () => {
+    const { loadConfigAsync } = await import("../config.js");
+    const { buildFromInclude } = await import("../../generator/index.js");
+    const { deployToMain } = await import("../../api/deploy.js");
+
+    vi.mocked(loadConfigAsync).mockResolvedValue({
+      include: ["tinybird/*.ts"],
+      token: "p.test-token",
+      baseUrl: "https://api.tinybird.co",
+      configPath: "/test/tinybird.config.json",
+      cwd: "/test",
+      gitBranch: "feature-pro-610",
+      tinybirdBranch: "feature_pro_610",
+      isMainBranch: false,
+      devMode: "branch",
+    });
+
+    vi.mocked(buildFromInclude).mockResolvedValue({
+      resources: {
+        datasources: [],
+        pipes: [],
+        connections: [],
+      },
+      entities: {
+        datasources: {},
+        pipes: {},
+        connections: {},
+        rawDatasources: [],
+        rawPipes: [],
+        sourceFiles: [],
+      },
+      stats: {
+        datasourceCount: 0,
+        pipeCount: 0,
+        connectionCount: 0,
+      },
+    });
+
+    vi.mocked(deployToMain).mockResolvedValue({
+      success: true,
+      result: "success",
+      datasourceCount: 0,
+      pipeCount: 0,
+      connectionCount: 0,
+    });
+
+    const result = await runDeploy({ allowDestructiveOperations: true });
+
+    expect(result.success).toBe(true);
+    expect(deployToMain).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        allowDestructiveOperations: true,
+      })
+    );
+  });
+});

--- a/src/cli/commands/deploy.ts
+++ b/src/cli/commands/deploy.ts
@@ -17,6 +17,8 @@ export interface DeployCommandOptions {
   dryRun?: boolean;
   /** Validate deploy with Tinybird API without applying */
   check?: boolean;
+  /** Allow deleting existing resources in main workspace deploys */
+  allowDestructiveOperations?: boolean;
   /** Callbacks for deploy progress */
   callbacks?: DeployCallbacks;
 }
@@ -103,6 +105,7 @@ export async function runDeploy(options: DeployCommandOptions = {}): Promise<Dep
       buildResult.resources,
       {
         check: options.check,
+        allowDestructiveOperations: options.allowDestructiveOperations,
         callbacks: options.callbacks,
       }
     );

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -432,6 +432,10 @@ function createCli(): Command {
     .description("Deploy resources to main Tinybird workspace (production)")
     .option("--dry-run", "Generate without pushing to API")
     .option("--check", "Validate deploy with Tinybird API without applying")
+    .option(
+      "--allow-destructive-operations",
+      "Allow deploys that delete existing datasources, pipes, or connections"
+    )
     .option("--debug", "Show debug output including API requests/responses")
     .action(async (options) => {
       if (options.debug) {
@@ -443,6 +447,7 @@ function createCli(): Command {
       const result = await runDeploy({
         dryRun: options.dryRun,
         check: options.check,
+        allowDestructiveOperations: options.allowDestructiveOperations,
         callbacks: {
           onChanges: (deployChanges) => {
             // Show changes table immediately after deployment is created


### PR DESCRIPTION
## Summary
- add `--allow-destructive-operations` to `tinybird deploy` and wire it through `runDeploy` -> `deployToMain`
- keep TS CLI behavior aligned with backend guidance by supporting destructive deploy opt-in
- append actionable guidance to Forward/Classic workspace deploy errors, pointing users to Tinybird Classic CLI (`tb`) in a Classic workspace
- add deploy tests for query param propagation and Forward/Classic guidance message

## Validation
- `pnpm -s vitest run src/api/deploy.test.ts src/cli/commands/deploy.test.ts`
- `pnpm -s typecheck`

## Linear
- https://linear.app/tinybird/issue/PRO-610/ts-cli-deploy-error-references-non-existent-allow-destructive