### PR TITLE
feat: add ingest retries for 429 and 503 with maxRetries

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,9 +258,7 @@ await api.ingest<EventRow>(
     pathname: "/pricing",
   },
   {
-    retry: {
-      maxRetries: 3,
-    },
+    maxRetries: 3,
   }
 );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybirdco/sdk",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "description": "TypeScript SDK for Tinybird Forward - define datasources and pipes as TypeScript",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/api/api.test.ts
+++ b/src/api/api.test.ts
@@ -257,9 +257,7 @@ describe("TinybirdApi", () => {
       "events",
       { timestamp: "2024-01-01 00:00:00" },
       {
-        retry: {
-          maxRetries: 1,
-        },
+        maxRetries: 1,
       }
     );
 
@@ -298,9 +296,7 @@ describe("TinybirdApi", () => {
       "events",
       { timestamp: "2024-01-01 00:00:00" },
       {
-        retry: {
-          maxRetries: 1,
-        },
+        maxRetries: 1,
       }
     );
 
@@ -355,9 +351,7 @@ describe("TinybirdApi", () => {
       "events",
       { timestamp: "2024-01-01 00:00:00" },
       {
-        retry: {
-          maxRetries: 1,
-        },
+        maxRetries: 1,
       }
     );
 
@@ -386,9 +380,7 @@ describe("TinybirdApi", () => {
         "events",
         { timestamp: "2024-01-01 00:00:00" },
         {
-          retry: {
-            maxRetries: 3,
-          },
+          maxRetries: 3,
         }
       )
     ).rejects.toMatchObject({
@@ -418,9 +410,7 @@ describe("TinybirdApi", () => {
         "events",
         { timestamp: "2024-01-01 00:00:00" },
         {
-          retry: {
-            maxRetries: 3,
-          },
+          maxRetries: 3,
         }
       )
     ).rejects.toMatchObject({
@@ -456,9 +446,7 @@ describe("TinybirdApi", () => {
         "events",
         { timestamp: "2024-01-01 00:00:00" },
         {
-          retry: {
-            maxRetries: 2,
-          },
+          maxRetries: 2,
         }
       )
     ).rejects.toMatchObject({
@@ -489,9 +477,7 @@ describe("TinybirdApi", () => {
         "events",
         { timestamp: "2024-01-01 00:00:00" },
         {
-          retry: {
-            maxRetries: 2,
-          },
+          maxRetries: 2,
         }
       )
     ).rejects.toMatchObject({
@@ -529,9 +515,7 @@ describe("TinybirdApi", () => {
       { timestamp: "2024-01-01 00:00:00" },
       {
         wait: false,
-        retry: {
-          maxRetries: 1,
-        },
+        maxRetries: 1,
       }
     );
 
@@ -563,9 +547,7 @@ describe("TinybirdApi", () => {
         { timestamp: "2024-01-01 00:00:00" },
         {
           wait: false,
-          retry: {
-            maxRetries: 3,
-          },
+          maxRetries: 3,
         }
       )
     ).rejects.toMatchObject({
@@ -607,9 +589,7 @@ describe("TinybirdApi", () => {
         "events",
         { timestamp: "2024-01-01 00:00:00" },
         {
-          retry: {
-            maxRetries: 1,
-          },
+          maxRetries: 1,
         }
       )
     ).rejects.toThrow("fetch failed");

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -14,7 +14,6 @@ import type {
 } from "../client/types.js";
 
 const DEFAULT_TIMEOUT = 30000;
-const DEFAULT_INGEST_RETRY_MAX_RETRIES = 2;
 const DEFAULT_INGEST_RETRY_503_BASE_DELAY_MS = 200;
 const DEFAULT_INGEST_RETRY_503_MAX_DELAY_MS = 3000;
 
@@ -65,10 +64,6 @@ export interface TinybirdApiDeleteOptions extends Omit<DeleteOptions, 'deleteCon
 export interface TinybirdApiTruncateOptions extends TruncateOptions {
   /** Optional token override for this request */
   token?: string;
-}
-
-interface NormalizedIngestRetryOptions {
-  maxRetries: number;
 }
 
 /**
@@ -287,7 +282,7 @@ export class TinybirdApi {
       .map((event) => JSON.stringify(this.serializeEvent(event)))
       .join("\n");
     const signal = this.createAbortSignal(options.timeout, options.signal);
-    const retryOptions = this.resolveIngestRetryOptions(options.retry);
+    const maxRetries = this.resolveIngestMaxRetries(options.maxRetries);
     let retryCount = 0;
 
     while (true) {
@@ -311,7 +306,7 @@ export class TinybirdApi {
         return (await response.json()) as IngestResult;
       }
 
-      const retry429Delay = this.resolveRetry429Delay(response, retryOptions, retryCount);
+      const retry429Delay = this.resolveRetry429Delay(response, maxRetries, retryCount);
       if (retry429Delay !== undefined) {
         await this.discardResponseBody(response);
         await this.sleep(retry429Delay, signal);
@@ -319,7 +314,7 @@ export class TinybirdApi {
         continue;
       }
 
-      const retry503Delay = this.resolveRetry503Delay(response, retryOptions, retryCount);
+      const retry503Delay = this.resolveRetry503Delay(response, maxRetries, retryCount);
       if (retry503Delay !== undefined) {
         await this.discardResponseBody(response);
         await this.sleep(retry503Delay, signal);
@@ -609,24 +604,26 @@ export class TinybirdApi {
     return AbortSignal.any([timeoutSignal, existingSignal]);
   }
 
-  private resolveIngestRetryOptions(
-    retry: TinybirdApiIngestOptions["retry"]
-  ): NormalizedIngestRetryOptions | undefined {
-    if (!retry) {
+  private resolveIngestMaxRetries(
+    maxRetries: TinybirdApiIngestOptions["maxRetries"]
+  ): number | undefined {
+    if (maxRetries === undefined) {
       return undefined;
     }
 
-    return {
-      maxRetries: retry.maxRetries ?? DEFAULT_INGEST_RETRY_MAX_RETRIES,
-    };
+    if (!Number.isFinite(maxRetries)) {
+      throw new Error("'maxRetries' must be a finite number");
+    }
+
+    return Math.max(0, Math.floor(maxRetries));
   }
 
   private resolveRetry429Delay(
     response: Response,
-    retryOptions: NormalizedIngestRetryOptions | undefined,
+    maxRetries: number | undefined,
     retryCount: number
   ): number | undefined {
-    if (!retryOptions) {
+    if (maxRetries === undefined) {
       return undefined;
     }
 
@@ -634,7 +631,7 @@ export class TinybirdApi {
       return undefined;
     }
 
-    if (retryCount >= retryOptions.maxRetries) {
+    if (retryCount >= maxRetries) {
       return undefined;
     }
 
@@ -643,10 +640,10 @@ export class TinybirdApi {
 
   private resolveRetry503Delay(
     response: Response,
-    retryOptions: NormalizedIngestRetryOptions | undefined,
+    maxRetries: number | undefined,
     retryCount: number
   ): number | undefined {
-    if (!retryOptions) {
+    if (maxRetries === undefined) {
       return undefined;
     }
 
@@ -654,7 +651,7 @@ export class TinybirdApi {
       return undefined;
     }
 
-    if (retryCount >= retryOptions.maxRetries) {
+    if (retryCount >= maxRetries) {
       return undefined;
     }
 

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -153,21 +153,8 @@ export interface IngestOptions {
   /** Wait for the ingestion to complete before returning */
   wait?: boolean;
   /**
-   * Retry strategy for transient ingest failures.
-   * Set to false to disable retries (default behavior).
-   */
-  retry?: IngestRetryOptions | false;
-}
-
-/**
- * Retry strategy for ingest requests.
- * - HTTP 429: retries require Retry-After or X-RateLimit-Reset headers.
- * - HTTP 503: retries use SDK default exponential backoff.
- */
-export interface IngestRetryOptions {
-  /**
    * Number of retry attempts after the first request.
-   * Example: 2 means at most 3 total attempts.
+   * Retries are disabled by default when undefined.
    */
   maxRetries?: number;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -249,7 +249,6 @@ export type {
   IngestResult,
   QueryOptions,
   IngestOptions,
-  IngestRetryOptions,
   TruncateOptions,
   TruncateResult,
   ColumnMeta,


### PR DESCRIPTION
## Summary
- add optional ingest retry config in IngestOptions via top-level maxRetries
- keep HTTP 429 retries header-driven (Retry-After / X-RateLimit-Reset)
- add HTTP 503 retries using SDK default exponential backoff (internal defaults)
- apply the same maxRetries cap to both 429 and 503 retries
- drain retryable response bodies before retrying
- simplify API by removing nested retry object from ingest options
- update README examples and unit tests for 429/503 behavior

## Validation
- pnpm typecheck
- pnpm exec vitest run src/api/api.test.ts