### PR TITLE
Fix migrate pipe SQL escaping

### DIFF
--- a/src/cli/commands/migrate.test.ts
+++ b/src/cli/commands/migrate.test.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { buildFromInclude } from "../../generator/index.js";
 import { runMigrate } from "./migrate.js";
 
 function writeFile(dir: string, relativePath: string, content: string): void {
@@ -1508,6 +1509,51 @@ TYPE endpoint
       'days: p.int32().optional(1).describe("Number of days to analyze (defaults to 1 day)"),'
     );
     expect(output).toContain("{{ Int32(days) }}");
+  });
+
+  it("escapes pipe SQL backslashes in migrated TypeScript template literals", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "tinybird-migrate-"));
+    tempDirs.push(tempDir);
+
+    writeFile(
+      tempDir,
+      "escape_percent.pipe",
+      String.raw`NODE endpoint
+SQL >
+  %
+  SELECT replaceAll({{ String(value) }}, '\\%', '%') AS value
+TYPE endpoint
+`
+    );
+
+    const result = await runMigrate({
+      cwd: tempDir,
+      patterns: ["."],
+      strict: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.errors).toHaveLength(0);
+
+    const output = fs.readFileSync(result.outputPath, "utf-8");
+    expect(output).toContain(
+      String.raw`SELECT replaceAll({{ String(value) }}, '\\\\%', '%') AS value`
+    );
+
+    fs.writeFileSync(
+      result.outputPath,
+      output.replace("@tinybirdco/sdk", path.resolve(process.cwd(), "src/index.ts"))
+    );
+
+    const build = await buildFromInclude({
+      cwd: tempDir,
+      includePaths: [result.outputPath],
+    });
+
+    expect(build.resources.pipes).toHaveLength(1);
+    expect(build.resources.pipes[0]?.content).toContain(
+      String.raw`SELECT replaceAll({{ String(value) }}, '\\%', '%') AS value`
+    );
   });
 
   it("migrates datasource with mixed explicit and default json paths", async () => {

--- a/src/migrate/emit-ts.ts
+++ b/src/migrate/emit-ts.ts
@@ -15,6 +15,10 @@ function escapeString(value: string): string {
   return JSON.stringify(value);
 }
 
+function escapeTemplateLiteral(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/`/g, "\\`").replace(/\${/g, "\\${");
+}
+
 function emitObjectKey(key: string): string {
   return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key) ? key : escapeString(key);
 }
@@ -378,7 +382,7 @@ function emitDatasource(ds: DatasourceModel): string {
 
   if (ds.forwardQuery) {
     lines.push("  forwardQuery: `");
-    lines.push(ds.forwardQuery.replace(/`/g, "\\`").replace(/\${/g, "\\${"));
+    lines.push(escapeTemplateLiteral(ds.forwardQuery));
     lines.push("  `,");
   }
 
@@ -561,7 +565,7 @@ function emitPipe(pipe: PipeModel): string {
       lines.push(`      description: ${escapeString(node.description)},`);
     }
     lines.push("      sql: `");
-    lines.push(node.sql.replace(/`/g, "\\`").replace(/\${/g, "\\${"));
+    lines.push(escapeTemplateLiteral(node.sql));
     lines.push("      `,");
     lines.push("    }),");
   }


### PR DESCRIPTION
## Summary

Fixes #148.

- Escapes backslashes when emitting migrated SQL into TypeScript template literals.
- Reuses the same template-literal escaping for migrated datasource `forwardQuery` content.
- Adds a regression test that migrates a `.pipe` containing `replaceAll({{ String(value) }}, '\\%', '%')`, checks the emitted TypeScript source, and verifies the generated `.pipe` preserves the original SQL.

## Automated checks

Run with Node 20 via nvm:

```bash
export NVM_DIR="$HOME/.nvm"
[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
nvm use 20
pnpm vitest run src/cli/commands/migrate.test.ts
pnpm typecheck
```

## Manual test script

Run this from the SDK repo checkout on this PR branch. It creates a throwaway project, installs this local SDK, migrates a legacy `.pipe`, generates datafiles from the migrated TypeScript, and asserts the escaping survives the round trip.

```bash
#!/usr/bin/env bash
set -euo pipefail

SDK_REPO="${SDK_REPO:-$(pwd)}"
WORKDIR="${WORKDIR:-$(mktemp -d /tmp/tb-sdk-escape-test-XXXXXX)}"

export NVM_DIR="$HOME/.nvm"
[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
nvm use 20 >/dev/null || nvm install 20

cd "$SDK_REPO"
pnpm install --frozen-lockfile
pnpm build

mkdir -p "$WORKDIR"
cd "$WORKDIR"

cat > package.json <<'JSON'
{
  "name": "tb-sdk-escape-manual-test",
  "private": true,
  "type": "module"
}
JSON

# Use the SDK from the checked-out PR branch, not the published package.
pnpm add "$SDK_REPO"

# generate only needs a config; it does not contact the API in this test.
cat > tinybird.config.json <<'JSON'
{
  "include": ["tinybird.migration.ts"],
  "token": "${TINYBIRD_TOKEN}",
  "baseUrl": "${TINYBIRD_BASE_URL}"
}
JSON

cat > .env.local <<'ENV'
TINYBIRD_TOKEN=manual-test-token
TINYBIRD_BASE_URL=https://api.tinybird.co
ENV

mkdir -p legacy
cat > legacy/escape_percent.pipe <<'PIPE'
NODE endpoint
SQL >
  %
  SELECT replaceAll({{ String(value) }}, '\\%', '%') AS value
TYPE endpoint
PIPE

TB=(node "$SDK_REPO/bin/tinybird.js")

# Optional: if you want to exercise auth too, uncomment this line.
# It opens the browser and rewrites .env.local with your real workspace token.
# "${TB[@]}" login

"${TB[@]}" migrate legacy --out tinybird.migration.ts --force
"${TB[@]}" generate --output-dir generated

python - <<'PY'
from pathlib import Path

migration = Path("tinybird.migration.ts").read_text()
generated_pipe = Path("generated/pipes/escape_percent.pipe").read_text()

expected_ts = r"SELECT replaceAll({{ String(value) }}, '\\\\%', '%') AS value"
expected_pipe = r"SELECT replaceAll({{ String(value) }}, '\\%', '%') AS value"

if expected_ts not in migration:
    raise SystemExit(f"Missing expected migrated TypeScript escaping:\n{expected_ts}\n\nActual file:\n{migration}")

if expected_pipe not in generated_pipe:
    raise SystemExit(f"Missing expected regenerated .pipe escaping:\n{expected_pipe}\n\nActual file:\n{generated_pipe}")

print("✅ Escaping round trip passed")
print(f"Project: {Path.cwd()}")
print("Migrate output: tinybird.migration.ts")
print("Generated pipe: generated/pipes/escape_percent.pipe")
PY
```

## Manual steps, expanded

1. Check out this PR branch locally:
   ```bash
   git fetch origin fix/migrate-pipe-escaping-148
   git switch fix/migrate-pipe-escaping-148
   ```
2. Use Node 20:
   ```bash
   export NVM_DIR="$HOME/.nvm"
   [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
   nvm use 20
   ```
3. Build the local SDK:
   ```bash
   pnpm install --frozen-lockfile
   pnpm build
   ```
4. Create a throwaway test project and install the local SDK checkout:
   ```bash
   TEST_DIR=$(mktemp -d /tmp/tb-sdk-escape-test-XXXXXX)
   cd "$TEST_DIR"
   printf '{"private":true,"type":"module"}\n' > package.json
   pnpm add /path/to/tinybird-sdk-typescript
   ```
5. Create `tinybird.config.json`:
   ```json
   {
     "include": ["tinybird.migration.ts"],
     "token": "${TINYBIRD_TOKEN}",
     "baseUrl": "${TINYBIRD_BASE_URL}"
   }
   ```
6. Either create dummy env values for local-only migrate/generate:
   ```bash
   cat > .env.local <<'ENV'
   TINYBIRD_TOKEN=manual-test-token
   TINYBIRD_BASE_URL=https://api.tinybird.co
   ENV
   ```
   Or run browser login if you also want to test auth/config writing:
   ```bash
   node /path/to/tinybird-sdk-typescript/bin/tinybird.js login
   ```
7. Create the legacy pipe:
   ```bash
   mkdir -p legacy
   cat > legacy/escape_percent.pipe <<'PIPE'
   NODE endpoint
   SQL >
     %
     SELECT replaceAll({{ String(value) }}, '\\%', '%') AS value
   TYPE endpoint
   PIPE
   ```
8. Migrate it with the local PR SDK:
   ```bash
   node /path/to/tinybird-sdk-typescript/bin/tinybird.js migrate legacy --out tinybird.migration.ts --force
   ```
9. Confirm migrated TypeScript contains four source backslashes before `%`:
   ```ts
   SELECT replaceAll({{ String(value) }}, '\\\\%', '%') AS value
   ```
10. Generate datafiles from the migrated TypeScript:
    ```bash
    node /path/to/tinybird-sdk-typescript/bin/tinybird.js generate --output-dir generated
    ```
11. Confirm regenerated `.pipe` contains the original two source backslashes before `%`:
    ```sql
    SELECT replaceAll({{ String(value) }}, '\\%', '%') AS value
    ```
