### PR TITLE
Fix pipe param metadata generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybirdco/sdk",
-  "version": "0.0.67",
+  "version": "0.0.68",
   "description": "TypeScript SDK for Tinybird Forward - define datasources and pipes as TypeScript",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/generator/pipe.test.ts
+++ b/src/generator/pipe.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { generatePipe, generateAllPipes } from './pipe.js';
-import { definePipe, defineMaterializedView, defineSinkPipe, node } from '../schema/pipe.js';
+import { definePipe, defineEndpoint, defineMaterializedView, defineSinkPipe, node } from '../schema/pipe.js';
 import { defineDatasource } from '../schema/datasource.js';
 import { defineKafkaConnection, defineS3Connection } from '../schema/connection.js';
 import { defineToken } from '../schema/token.js';
@@ -182,8 +182,8 @@ describe('Pipe Generator', () => {
       });
 
       const result = generatePipe(pipe);
-      expect(result.content).toContain("{{ Date(start_date, '2025-03-01') }}");
-      expect(result.content).toContain('{{ Int32(page, 0) }}');
+      expect(result.content).toContain("{{ Date(start_date, '2025-03-01', required=False) }}");
+      expect(result.content).toContain('{{ Int32(page, 0, required=False) }}');
     });
   });
 
@@ -254,6 +254,77 @@ describe('Pipe Generator', () => {
       const result = generatePipe(pipe);
       expect(result.content).toContain('CACHE 60');
     });
+
+    it('emits explicit required and description metadata for endpoint params', () => {
+      const pipe = definePipe('account_demos', {
+        params: {
+          id: p.string().required().describe('The company account ID'),
+          workspaceId: p.string().required().describe('The workspace ID'),
+        },
+        nodes: [
+          node({
+            name: 'endpoint',
+            sql: `
+SELECT *
+FROM events
+WHERE workspaceId = {{ String(workspaceId) }}
+  AND companyAccountId = {{ String(id) }}
+            `.trim(),
+          }),
+        ],
+        output: simpleOutput,
+        endpoint: true,
+      });
+
+      const result = generatePipe(pipe);
+      expect(result.content).toContain(
+        '{{ String(workspaceId, required=True, description="The workspace ID") }}'
+      );
+      expect(result.content).toContain(
+        '{{ String(id, required=True, description="The company account ID") }}'
+      );
+    });
+
+    it('emits optional metadata without duplicating existing default or description args', () => {
+      const pipe = definePipe('test_pipe', {
+        params: {
+          limit: p.int32().optional(10).describe('Number of rows'),
+        },
+        nodes: [
+          node({
+            name: 'endpoint',
+            sql: 'SELECT * FROM events LIMIT {{ Int32(limit, 10, description="Existing") }}',
+          }),
+        ],
+        output: simpleOutput,
+        endpoint: true,
+      });
+
+      const result = generatePipe(pipe);
+      expect(result.content).toContain(
+        '{{ Int32(limit, 10, description="Existing", required=False) }}'
+      );
+    });
+
+    it('emits param metadata for defineEndpoint helper', () => {
+      const pipe = defineEndpoint('test_endpoint', {
+        params: {
+          workspaceId: p.string().required().describe('The workspace ID'),
+        },
+        nodes: [
+          node({
+            name: 'endpoint',
+            sql: 'SELECT * FROM events WHERE workspaceId = {{ String(workspaceId) }}',
+          }),
+        ],
+        output: simpleOutput,
+      });
+
+      const result = generatePipe(pipe);
+      expect(result.content).toContain(
+        '{{ String(workspaceId, required=True, description="The workspace ID") }}'
+      );
+    });
   });
 
   describe('generateAllPipes', () => {
@@ -317,7 +388,7 @@ LIMIT {{Int32(limit, 10)}}
       expect(result.content).toContain('    %\n');
       expect(result.content).toContain('pathname');
       expect(result.content).toContain('{{DateTime(start_date)}}');
-      expect(result.content).toContain('{{Int32(limit, 10)}}');
+      expect(result.content).toContain('{{ Int32(limit, 10, required=False) }}');
       expect(result.content).toContain('TYPE endpoint');
     });
   });

--- a/src/generator/pipe.ts
+++ b/src/generator/pipe.ts
@@ -19,7 +19,12 @@ import {
   getSinkConfig,
 } from "../schema/pipe.js";
 import type { AnyParamValidator } from "../schema/params.js";
-import { getParamDefault } from "../schema/params.js";
+import {
+  getParamDefault,
+  getParamDescription,
+  getParamRequiredModifier,
+  isParamRequired,
+} from "../schema/params.js";
 
 /**
  * Generated pipe content
@@ -96,23 +101,57 @@ function toTemplateDefaultLiteral(value: string | number | boolean): string {
   return String(value);
 }
 
-function applyParamDefaultsToSql(
+function toTemplateStringLiteral(value: string): string {
+  return JSON.stringify(value);
+}
+
+function hasKeywordArg(args: string[], key: string): boolean {
+  const keyLower = key.toLowerCase();
+  return args.some((arg) => {
+    const equalsIndex = arg.indexOf("=");
+    if (equalsIndex <= 0) {
+      return false;
+    }
+    return arg.slice(0, equalsIndex).trim().toLowerCase() === keyLower;
+  });
+}
+
+function hasPositionalDefaultArg(args: string[]): boolean {
+  return args.slice(1).some((arg) => !/^[a-zA-Z_][a-zA-Z0-9_]*\s*=/.test(arg.trim()));
+}
+
+function buildParamTemplateArgs(
+  args: string[],
+  validator: AnyParamValidator
+): string[] {
+  const nextArgs = [...args];
+  const defaultValue = getParamDefault(validator);
+  if (
+    defaultValue !== undefined &&
+    !hasPositionalDefaultArg(nextArgs) &&
+    !hasKeywordArg(nextArgs, "default")
+  ) {
+    nextArgs.push(toTemplateDefaultLiteral(defaultValue as string | number | boolean));
+  }
+
+  const requiredModifier = getParamRequiredModifier(validator);
+  if (requiredModifier && !hasKeywordArg(nextArgs, "required")) {
+    nextArgs.push(`required=${isParamRequired(validator) ? "True" : "False"}`);
+  }
+
+  const description = getParamDescription(validator);
+  if (description !== undefined && !hasKeywordArg(nextArgs, "description")) {
+    nextArgs.push(`description=${toTemplateStringLiteral(description)}`);
+  }
+
+  return nextArgs;
+}
+
+function applyParamMetadataToSql(
   sql: string,
   params?: Record<string, AnyParamValidator>
 ): string {
   if (!params) {
-    return sql;
-  }
-
-  const defaults = new Map<string, string>();
-  for (const [name, validator] of Object.entries(params)) {
-    const defaultValue = getParamDefault(validator);
-    if (defaultValue !== undefined) {
-      defaults.set(name, toTemplateDefaultLiteral(defaultValue as string | number | boolean));
-    }
-  }
-
-  if (defaults.size === 0) {
     return sql;
   }
 
@@ -123,7 +162,7 @@ function applyParamDefaultsToSql(
       /([a-zA-Z_][a-zA-Z0-9_]*)\s*\(([^()]*)\)/g,
       (call, _functionName, rawArgs) => {
         const args = splitTopLevelComma(String(rawArgs));
-        if (args.length !== 1) {
+        if (args.length === 0) {
           return call;
         }
 
@@ -132,12 +171,17 @@ function applyParamDefaultsToSql(
           return call;
         }
 
-        const defaultLiteral = defaults.get(paramName);
-        if (!defaultLiteral) {
+        const validator = params[paramName];
+        if (!validator) {
           return call;
         }
 
-        return call.replace(/\)\s*$/, `, ${defaultLiteral})`);
+        const nextArgs = buildParamTemplateArgs(args, validator);
+        if (nextArgs.length === args.length) {
+          return call;
+        }
+
+        return call.replace(/\([^()]*\)\s*$/, `(${nextArgs.join(", ")})`);
       }
     );
 
@@ -172,8 +216,8 @@ function generateNode(
     parts.push(`    %`);
   }
 
-  const sqlWithDefaults = applyParamDefaultsToSql(node.sql, params);
-  const sqlLines = sqlWithDefaults.trim().split("\n");
+  const sqlWithParamMetadata = applyParamMetadataToSql(node.sql, params);
+  const sqlLines = sqlWithParamMetadata.trim().split("\n");
   sqlLines.forEach((line) => {
     parts.push(`    ${line}`);
   });

--- a/src/schema/params.test.ts
+++ b/src/schema/params.test.ts
@@ -111,6 +111,7 @@ describe('Parameter Validators (p.*)', () => {
       const param = p.int32().optional();
       expect(param._required).toBe(false);
       expect(param._default).toBeUndefined();
+      expect(param._requiredModifier).toBe('optional');
     });
 
     it('makes parameter optional with default value', () => {
@@ -130,6 +131,11 @@ describe('Parameter Validators (p.*)', () => {
     it('makes optional parameter required again', () => {
       const param = p.int32().optional(10).required();
       expect(param._required).toBe(true);
+    });
+
+    it('tracks explicit required modifier separately from required by default', () => {
+      expect(p.string()._requiredModifier).toBeUndefined();
+      expect(p.string().required()._requiredModifier).toBe('required');
     });
   });
 

--- a/src/schema/params.ts
+++ b/src/schema/params.ts
@@ -26,6 +26,8 @@ export interface ParamValidator<
   readonly _default?: TType;
   /** Description for documentation */
   readonly _description?: string;
+  /** Whether required/optional was explicitly set by a modifier */
+  readonly _requiredModifier?: "required" | "optional";
 
   /** Make this parameter optional with an optional default value */
   optional<TDefault extends TType | undefined = undefined>(
@@ -62,6 +64,7 @@ function createParamValidator<
     required?: TRequired;
     defaultValue?: TType;
     description?: string;
+    requiredModifier?: "required" | "optional";
   } = {}
 ): ParamValidator<TType, TTinybirdType, TRequired> {
   const isRequired = (options.required ?? true) as TRequired;
@@ -73,6 +76,7 @@ function createParamValidator<
     _required: isRequired,
     _default: options.defaultValue,
     _description: options.description,
+    _requiredModifier: options.requiredModifier,
     tinybirdType,
     isRequired,
     defaultValue: options.defaultValue,
@@ -87,6 +91,7 @@ function createParamValidator<
         required: false,
         defaultValue: defaultValue as TDefault extends undefined ? TType | undefined : TType,
         description: options.description,
+        requiredModifier: "optional",
       });
     },
 
@@ -94,6 +99,7 @@ function createParamValidator<
       return createParamValidator<TType, TTinybirdType, true>(tinybirdType, {
         required: true,
         description: options.description,
+        requiredModifier: "required",
       });
     },
 
@@ -102,6 +108,7 @@ function createParamValidator<
         required: isRequired,
         defaultValue: options.defaultValue,
         description,
+        requiredModifier: options.requiredModifier,
       });
     },
   };
@@ -247,4 +254,11 @@ export function getParamDefault<T>(validator: ParamValidator<T, string, boolean>
 /** Get the description of a parameter */
 export function getParamDescription(validator: AnyParamValidator): string | undefined {
   return validator._description;
+}
+
+/** Check whether required/optional was explicitly set by a modifier */
+export function getParamRequiredModifier(
+  validator: AnyParamValidator
+): "required" | "optional" | undefined {
+  return validator._requiredModifier;
 }


### PR DESCRIPTION
## Summary
- track explicit `required()` / `optional()` param modifiers separately from default required state
- serialize `required=True`, `required=False`, and `description=...` into generated pipe template placeholders
- add regression coverage for endpoint pipes and the `defineEndpoint` helper

## Verification
- `pnpm vitest run src/schema/params.test.ts src/generator/pipe.test.ts`
- `pnpm typecheck`

## Notes
- `pnpm test:run` still fails in unrelated `e2e/init-build.test.ts` cases because this local run detects the git branch as `main` and the build command refuses main-workspace deployment.
