### PR TITLE
Fix column param metadata generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybirdco/sdk",
-  "version": "0.0.68",
+  "version": "0.0.69",
   "description": "TypeScript SDK for Tinybird Forward - define datasources and pipes as TypeScript",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/generator/pipe.test.ts
+++ b/src/generator/pipe.test.ts
@@ -306,6 +306,27 @@ WHERE workspaceId = {{ String(workspaceId) }}
       );
     });
 
+    it('does not emit unsupported keyword args for column params', () => {
+      const pipe = definePipe('visitor_filters', {
+        params: {
+          orderBy: p.column().optional('lastSeen').describe('Column used for sorting'),
+        },
+        nodes: [
+          node({
+            name: 'endpoint',
+            sql: 'SELECT * FROM visitors ORDER BY {{ column(orderBy) }}',
+          }),
+        ],
+        output: simpleOutput,
+        endpoint: true,
+      });
+
+      const result = generatePipe(pipe);
+      expect(result.content).toContain("{{ column(orderBy, 'lastSeen') }}");
+      expect(result.content).not.toContain('column(orderBy, \'lastSeen\', required=False)');
+      expect(result.content).not.toContain('description="Column used for sorting"');
+    });
+
     it('emits param metadata for defineEndpoint helper', () => {
       const pipe = defineEndpoint('test_endpoint', {
         params: {

--- a/src/generator/pipe.ts
+++ b/src/generator/pipe.ts
@@ -22,6 +22,7 @@ import type { AnyParamValidator } from "../schema/params.js";
 import {
   getParamDefault,
   getParamDescription,
+  getParamTinybirdType,
   getParamRequiredModifier,
   isParamRequired,
 } from "../schema/params.js";
@@ -132,6 +133,10 @@ function buildParamTemplateArgs(
     !hasKeywordArg(nextArgs, "default")
   ) {
     nextArgs.push(toTemplateDefaultLiteral(defaultValue as string | number | boolean));
+  }
+
+  if (getParamTinybirdType(validator) === "column") {
+    return nextArgs;
   }
 
   const requiredModifier = getParamRequiredModifier(validator);


### PR DESCRIPTION
## Summary
- skip `required` and `description` keyword emission for `p.column()` parameters
- keep positional default injection so `p.column().optional("lastSeen")` generates `{{ column(orderBy, 'lastSeen') }}`
- add regression coverage for Tinybird's `column()` template helper behavior

## Docs checked
- Tinybird query parameter docs document `column()` separately as `{{column(order_by, 'timestamp')}}` and recommend the second positional default argument.
- The generic `description=...` / `required=...` signature is shown for typed dynamic parameters, while `column()` examples do not use those kwargs.

## Verification
- `pnpm vitest run src/generator/pipe.test.ts src/schema/params.test.ts`
- `pnpm typecheck`
