### PR TITLE
Support Kafka IAM auth fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybirdco/sdk",
-  "version": "0.0.73",
+  "version": "0.0.74",
   "description": "TypeScript SDK for Tinybird Forward - define datasources and pipes as TypeScript",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli/commands/migrate.test.ts
+++ b/src/cli/commands/migrate.test.ts
@@ -845,6 +845,12 @@ INDEXES >
       "stream.connection",
       `TYPE kafka
 KAFKA_BOOTSTRAP_SERVERS kafka.example.com:9092
+KAFKA_SECURITY_PROTOCOL SASL_SSL
+KAFKA_SASL_MECHANISM OAUTHBEARER
+KAFKA_SASL_OAUTHBEARER_METHOD AWS
+KAFKA_SASL_OAUTHBEARER_AWS_REGION eu-west-1
+KAFKA_SASL_OAUTHBEARER_AWS_ROLE_ARN {{ tb_secret("KAFKA_AWS_ROLE_ARN") }}
+KAFKA_SASL_OAUTHBEARER_AWS_EXTERNAL_ID {{ tb_secret("KAFKA_AWS_EXTERNAL_ID") }}
 KAFKA_SCHEMA_REGISTRY_URL https://registry-user:registry-pass@registry.example.com
 # Optional registry auth details
 `
@@ -909,6 +915,11 @@ DATASOURCE events_state
     expect(output).toContain(
       'schemaRegistryUrl: "https://registry-user:registry-pass@registry.example.com"'
     );
+    expect(output).toContain('saslMechanism: "OAUTHBEARER"');
+    expect(output).toContain('saslOauthbearerMethod: "AWS"');
+    expect(output).toContain('saslOauthbearerAwsRegion: "eu-west-1"');
+    expect(output).toContain('saslOauthbearerAwsRoleArn: secret("KAFKA_AWS_ROLE_ARN")');
+    expect(output).toContain('saslOauthbearerAwsExternalId: secret("KAFKA_AWS_EXTERNAL_ID")');
     expect(output).toContain("storeRawValue: true");
     expect(output).toContain(
       'engine: engine.replacingMergeTree({ sortingKey: "event_id", ver: "version_ts", isDeleted: "_is_deleted" })'

--- a/src/generator/connection.test.ts
+++ b/src/generator/connection.test.ts
@@ -152,6 +152,29 @@ describe("Connection Generator", () => {
       });
     });
 
+    it("generates Kafka AWS IAM OAUTHBEARER settings", () => {
+      const conn = defineKafkaConnection("aws_msk", {
+        bootstrapServers: "b-1.msk.example.com:9098,b-2.msk.example.com:9098",
+        securityProtocol: "SASL_SSL",
+        saslMechanism: "OAUTHBEARER",
+        saslOauthbearerMethod: "AWS",
+        saslOauthbearerAwsRegion: "eu-west-1",
+        saslOauthbearerAwsRoleArn: '{{ tb_secret("KAFKA_AWS_ROLE_ARN") }}',
+        saslOauthbearerAwsExternalId: '{{ tb_secret("KAFKA_AWS_EXTERNAL_ID") }}',
+      });
+
+      const result = generateConnection(conn);
+
+      expect(result.content).toContain("KAFKA_SASL_OAUTHBEARER_METHOD AWS");
+      expect(result.content).toContain("KAFKA_SASL_OAUTHBEARER_AWS_REGION eu-west-1");
+      expect(result.content).toContain(
+        'KAFKA_SASL_OAUTHBEARER_AWS_ROLE_ARN {{ tb_secret("KAFKA_AWS_ROLE_ARN") }}'
+      );
+      expect(result.content).toContain(
+        'KAFKA_SASL_OAUTHBEARER_AWS_EXTERNAL_ID {{ tb_secret("KAFKA_AWS_EXTERNAL_ID") }}'
+      );
+    });
+
     it("generates basic S3 connection with IAM role auth", () => {
       const conn = defineS3Connection("my_s3", {
         region: "us-east-1",

--- a/src/generator/connection.ts
+++ b/src/generator/connection.ts
@@ -42,6 +42,22 @@ function generateKafkaConnection(connection: KafkaConnectionDefinition): string 
     parts.push(`KAFKA_SASL_MECHANISM ${options.saslMechanism}`);
   }
 
+  if (options.saslOauthbearerMethod) {
+    parts.push(`KAFKA_SASL_OAUTHBEARER_METHOD ${options.saslOauthbearerMethod}`);
+  }
+
+  if (options.saslOauthbearerAwsRegion) {
+    parts.push(`KAFKA_SASL_OAUTHBEARER_AWS_REGION ${options.saslOauthbearerAwsRegion}`);
+  }
+
+  if (options.saslOauthbearerAwsRoleArn) {
+    parts.push(`KAFKA_SASL_OAUTHBEARER_AWS_ROLE_ARN ${options.saslOauthbearerAwsRoleArn}`);
+  }
+
+  if (options.saslOauthbearerAwsExternalId) {
+    parts.push(`KAFKA_SASL_OAUTHBEARER_AWS_EXTERNAL_ID ${options.saslOauthbearerAwsExternalId}`);
+  }
+
   if (options.key) {
     parts.push(`KAFKA_KEY ${options.key}`);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,6 +137,7 @@ export type {
   KafkaConnectionOptions,
   KafkaSecurityProtocol,
   KafkaSaslMechanism,
+  KafkaSaslOauthbearerMethod,
   S3ConnectionDefinition,
   S3ConnectionOptions,
   GCSConnectionDefinition,

--- a/src/migrate/emit-ts.ts
+++ b/src/migrate/emit-ts.ts
@@ -64,6 +64,9 @@ function hasSecretTemplate(resources: ParsedResource[]): boolean {
         if (resource.secret) values.push(resource.secret);
         if (resource.sslCaPem) values.push(resource.sslCaPem);
         if (resource.schemaRegistryUrl) values.push(resource.schemaRegistryUrl);
+        if (resource.saslOauthbearerAwsRegion) values.push(resource.saslOauthbearerAwsRegion);
+        if (resource.saslOauthbearerAwsRoleArn) values.push(resource.saslOauthbearerAwsRoleArn);
+        if (resource.saslOauthbearerAwsExternalId) values.push(resource.saslOauthbearerAwsExternalId);
       } else if (resource.connectionType === "s3") {
         values.push(resource.region);
         if (resource.arn) values.push(resource.arn);
@@ -428,6 +431,24 @@ function emitConnection(
     }
     if (connection.saslMechanism) {
       lines.push(`  saslMechanism: ${emitStringOrSecret(connection.saslMechanism)},`);
+    }
+    if (connection.saslOauthbearerMethod) {
+      lines.push(`  saslOauthbearerMethod: ${emitStringOrSecret(connection.saslOauthbearerMethod)},`);
+    }
+    if (connection.saslOauthbearerAwsRegion) {
+      lines.push(
+        `  saslOauthbearerAwsRegion: ${emitStringOrSecret(connection.saslOauthbearerAwsRegion)},`
+      );
+    }
+    if (connection.saslOauthbearerAwsRoleArn) {
+      lines.push(
+        `  saslOauthbearerAwsRoleArn: ${emitStringOrSecret(connection.saslOauthbearerAwsRoleArn)},`
+      );
+    }
+    if (connection.saslOauthbearerAwsExternalId) {
+      lines.push(
+        `  saslOauthbearerAwsExternalId: ${emitStringOrSecret(connection.saslOauthbearerAwsExternalId)},`
+      );
     }
     if (connection.key) {
       lines.push(`  key: ${emitStringOrSecret(connection.key)},`);

--- a/src/migrate/parse-connection.test.ts
+++ b/src/migrate/parse-connection.test.ts
@@ -95,4 +95,31 @@ KAFKA_SSL_CA_PEM {{ tb_secret('KAFKA_SSL_CA_PEM') }}`
 
     expect(result).toHaveProperty("sslCaPem", "{{ tb_secret('KAFKA_SSL_CA_PEM') }}");
   });
+
+  it("parses Kafka AWS IAM OAUTHBEARER directives", () => {
+    const result = parseConnectionFile(
+      resource(
+        "aws_msk",
+        `TYPE kafka
+KAFKA_BOOTSTRAP_SERVERS b-1.msk.example.com:9098,b-2.msk.example.com:9098
+KAFKA_SECURITY_PROTOCOL SASL_SSL
+KAFKA_SASL_MECHANISM OAUTHBEARER
+KAFKA_SASL_OAUTHBEARER_METHOD AWS
+KAFKA_SASL_OAUTHBEARER_AWS_REGION eu-west-1
+KAFKA_SASL_OAUTHBEARER_AWS_ROLE_ARN {{ tb_secret("KAFKA_AWS_ROLE_ARN") }}
+KAFKA_SASL_OAUTHBEARER_AWS_EXTERNAL_ID {{ tb_secret("KAFKA_AWS_EXTERNAL_ID") }}`
+      )
+    );
+
+    expect(result).toHaveProperty("saslOauthbearerMethod", "AWS");
+    expect(result).toHaveProperty("saslOauthbearerAwsRegion", "eu-west-1");
+    expect(result).toHaveProperty(
+      "saslOauthbearerAwsRoleArn",
+      '{{ tb_secret("KAFKA_AWS_ROLE_ARN") }}'
+    );
+    expect(result).toHaveProperty(
+      "saslOauthbearerAwsExternalId",
+      '{{ tb_secret("KAFKA_AWS_EXTERNAL_ID") }}'
+    );
+  });
 });

--- a/src/migrate/parse-connection.ts
+++ b/src/migrate/parse-connection.ts
@@ -18,6 +18,10 @@ const CONNECTION_DIRECTIVES = new Set([
   "KAFKA_BOOTSTRAP_SERVERS",
   "KAFKA_SECURITY_PROTOCOL",
   "KAFKA_SASL_MECHANISM",
+  "KAFKA_SASL_OAUTHBEARER_METHOD",
+  "KAFKA_SASL_OAUTHBEARER_AWS_REGION",
+  "KAFKA_SASL_OAUTHBEARER_AWS_ROLE_ARN",
+  "KAFKA_SASL_OAUTHBEARER_AWS_EXTERNAL_ID",
   "KAFKA_KEY",
   "KAFKA_SECRET",
   "KAFKA_SCHEMA_REGISTRY_URL",
@@ -55,6 +59,10 @@ export function parseConnectionFile(
     | "SCRAM-SHA-512"
     | "OAUTHBEARER"
     | undefined;
+  let saslOauthbearerMethod: "AWS" | undefined;
+  let saslOauthbearerAwsRegion: string | undefined;
+  let saslOauthbearerAwsRoleArn: string | undefined;
+  let saslOauthbearerAwsExternalId: string | undefined;
   let key: string | undefined;
   let secret: string | undefined;
   let schemaRegistryUrl: string | undefined;
@@ -109,6 +117,26 @@ export function parseConnectionFile(
           );
         }
         saslMechanism = value;
+        break;
+      case "KAFKA_SASL_OAUTHBEARER_METHOD":
+        if (value !== "AWS") {
+          throw new MigrationParseError(
+            resource.filePath,
+            "connection",
+            resource.name,
+            `Unsupported KAFKA_SASL_OAUTHBEARER_METHOD: "${value}"`
+          );
+        }
+        saslOauthbearerMethod = value;
+        break;
+      case "KAFKA_SASL_OAUTHBEARER_AWS_REGION":
+        saslOauthbearerAwsRegion = value;
+        break;
+      case "KAFKA_SASL_OAUTHBEARER_AWS_ROLE_ARN":
+        saslOauthbearerAwsRoleArn = value;
+        break;
+      case "KAFKA_SASL_OAUTHBEARER_AWS_EXTERNAL_ID":
+        saslOauthbearerAwsExternalId = value;
         break;
       case "KAFKA_KEY":
         key = value;
@@ -196,6 +224,10 @@ export function parseConnectionFile(
       bootstrapServers,
       securityProtocol,
       saslMechanism,
+      saslOauthbearerMethod,
+      saslOauthbearerAwsRegion,
+      saslOauthbearerAwsRoleArn,
+      saslOauthbearerAwsExternalId,
       key,
       secret,
       schemaRegistryUrl,
@@ -208,6 +240,10 @@ export function parseConnectionFile(
       bootstrapServers ||
       securityProtocol ||
       saslMechanism ||
+      saslOauthbearerMethod ||
+      saslOauthbearerAwsRegion ||
+      saslOauthbearerAwsRoleArn ||
+      saslOauthbearerAwsExternalId ||
       key ||
       secret ||
       schemaRegistryUrl ||
@@ -266,6 +302,10 @@ export function parseConnectionFile(
       bootstrapServers ||
       securityProtocol ||
       saslMechanism ||
+      saslOauthbearerMethod ||
+      saslOauthbearerAwsRegion ||
+      saslOauthbearerAwsRoleArn ||
+      saslOauthbearerAwsExternalId ||
       key ||
       secret ||
       schemaRegistryUrl ||

--- a/src/migrate/types.ts
+++ b/src/migrate/types.ts
@@ -155,6 +155,10 @@ export interface KafkaConnectionModel {
   bootstrapServers: string;
   securityProtocol?: "SASL_SSL" | "PLAINTEXT" | "SASL_PLAINTEXT";
   saslMechanism?: "PLAIN" | "SCRAM-SHA-256" | "SCRAM-SHA-512" | "OAUTHBEARER";
+  saslOauthbearerMethod?: "AWS";
+  saslOauthbearerAwsRegion?: string;
+  saslOauthbearerAwsRoleArn?: string;
+  saslOauthbearerAwsExternalId?: string;
   key?: string;
   secret?: string;
   schemaRegistryUrl?: string;

--- a/src/schema/connection.test.ts
+++ b/src/schema/connection.test.ts
@@ -60,6 +60,27 @@ describe("Connection Schema", () => {
       expect(oauthConn.options.saslMechanism).toBe("OAUTHBEARER");
     });
 
+    it("creates a Kafka connection with AWS IAM OAUTHBEARER auth", () => {
+      const conn = defineKafkaConnection("aws_msk", {
+        bootstrapServers: "b-1.msk.example.com:9098,b-2.msk.example.com:9098",
+        securityProtocol: "SASL_SSL",
+        saslMechanism: "OAUTHBEARER",
+        saslOauthbearerMethod: "AWS",
+        saslOauthbearerAwsRegion: "eu-west-1",
+        saslOauthbearerAwsRoleArn: '{{ tb_secret("KAFKA_AWS_ROLE_ARN") }}',
+        saslOauthbearerAwsExternalId: '{{ tb_secret("KAFKA_AWS_EXTERNAL_ID") }}',
+      });
+
+      expect(conn.options.saslOauthbearerMethod).toBe("AWS");
+      expect(conn.options.saslOauthbearerAwsRegion).toBe("eu-west-1");
+      expect(conn.options.saslOauthbearerAwsRoleArn).toBe(
+        '{{ tb_secret("KAFKA_AWS_ROLE_ARN") }}'
+      );
+      expect(conn.options.saslOauthbearerAwsExternalId).toBe(
+        '{{ tb_secret("KAFKA_AWS_EXTERNAL_ID") }}'
+      );
+    });
+
     it("supports different security protocols", () => {
       const plaintext = defineKafkaConnection("plaintext_kafka", {
         bootstrapServers: "localhost:9092",

--- a/src/schema/connection.ts
+++ b/src/schema/connection.ts
@@ -18,6 +18,11 @@ export type KafkaSecurityProtocol = "SASL_SSL" | "PLAINTEXT" | "SASL_PLAINTEXT";
 export type KafkaSaslMechanism = "PLAIN" | "SCRAM-SHA-256" | "SCRAM-SHA-512" | "OAUTHBEARER";
 
 /**
+ * Kafka SASL OAUTHBEARER provider method options
+ */
+export type KafkaSaslOauthbearerMethod = "AWS";
+
+/**
  * Options for creating a Kafka connection
  */
 export interface KafkaConnectionOptions {
@@ -27,6 +32,14 @@ export interface KafkaConnectionOptions {
   securityProtocol?: KafkaSecurityProtocol;
   /** SASL mechanism for authentication */
   saslMechanism?: KafkaSaslMechanism;
+  /** SASL OAUTHBEARER provider method */
+  saslOauthbearerMethod?: KafkaSaslOauthbearerMethod;
+  /** AWS region for SASL OAUTHBEARER IAM authentication */
+  saslOauthbearerAwsRegion?: string;
+  /** AWS role ARN for SASL OAUTHBEARER IAM authentication */
+  saslOauthbearerAwsRoleArn?: string;
+  /** AWS external ID for SASL OAUTHBEARER IAM authentication */
+  saslOauthbearerAwsExternalId?: string;
   /** Kafka key/username - can use {{ tb_secret(...) }} */
   key?: string;
   /** Kafka secret/password - can use {{ tb_secret(...) }} */


### PR DESCRIPTION
## What changed

- Added Kafka AWS IAM/OAUTHBEARER auth options to `defineKafkaConnection`.
- Emitted the matching `.connection` directives:
  - `KAFKA_SASL_OAUTHBEARER_METHOD`
  - `KAFKA_SASL_OAUTHBEARER_AWS_REGION`
  - `KAFKA_SASL_OAUTHBEARER_AWS_ROLE_ARN`
  - `KAFKA_SASL_OAUTHBEARER_AWS_EXTERNAL_ID`
- Updated migration parsing and TypeScript emission so existing `.connection` files round-trip into SDK definitions.
- Bumped `@tinybirdco/sdk` to `0.0.74`.

## Why

`../analytics` supports Kafka IAM authentication through those OAUTHBEARER AWS fields in connection datafiles. The SDK can now author and migrate those definitions.

## Example

Authoring the connection in TypeScript:

```ts
import { defineKafkaConnection, secret } from "@tinybirdco/sdk";

export const awsMsk = defineKafkaConnection("aws_msk", {
  bootstrapServers: "b-1.msk.example.com:9098,b-2.msk.example.com:9098",
  securityProtocol: "SASL_SSL",
  saslMechanism: "OAUTHBEARER",
  saslOauthbearerMethod: "AWS",
  saslOauthbearerAwsRegion: "eu-west-1",
  saslOauthbearerAwsRoleArn: secret("KAFKA_AWS_ROLE_ARN"),
  saslOauthbearerAwsExternalId: secret("KAFKA_AWS_EXTERNAL_ID"),
});
```

Generated `.connection` datafile, which is also what migration parsing reads later:

```text
TYPE kafka
KAFKA_BOOTSTRAP_SERVERS b-1.msk.example.com:9098,b-2.msk.example.com:9098
KAFKA_SECURITY_PROTOCOL SASL_SSL
KAFKA_SASL_MECHANISM OAUTHBEARER
KAFKA_SASL_OAUTHBEARER_METHOD AWS
KAFKA_SASL_OAUTHBEARER_AWS_REGION eu-west-1
KAFKA_SASL_OAUTHBEARER_AWS_ROLE_ARN {{ tb_secret("KAFKA_AWS_ROLE_ARN") }}
KAFKA_SASL_OAUTHBEARER_AWS_EXTERNAL_ID {{ tb_secret("KAFKA_AWS_EXTERNAL_ID") }}
```

When migrating that datafile back to TypeScript, the parser emits the same SDK options:

```ts
export const awsMsk = defineKafkaConnection("aws_msk", {
  bootstrapServers: "b-1.msk.example.com:9098,b-2.msk.example.com:9098",
  securityProtocol: "SASL_SSL",
  saslMechanism: "OAUTHBEARER",
  saslOauthbearerMethod: "AWS",
  saslOauthbearerAwsRegion: "eu-west-1",
  saslOauthbearerAwsRoleArn: secret("KAFKA_AWS_ROLE_ARN"),
  saslOauthbearerAwsExternalId: secret("KAFKA_AWS_EXTERNAL_ID"),
});
```

## Validation

- `pnpm vitest run src/schema/connection.test.ts src/generator/connection.test.ts src/migrate/parse-connection.test.ts src/cli/commands/migrate.test.ts`
- `pnpm typecheck`
- `pnpm test:run`
- `pnpm build`