### PR TITLE
Add datasource BACKFILL skip support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybirdco/sdk",
-  "version": "0.0.75",
+  "version": "0.0.76",
   "description": "TypeScript SDK for Tinybird Forward - define datasources and pipes as TypeScript",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinybirdco/sdk",
-  "version": "0.0.74",
+  "version": "0.0.75",
   "description": "TypeScript SDK for Tinybird Forward - define datasources and pipes as TypeScript",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/generator/datasource.test.ts
+++ b/src/generator/datasource.test.ts
@@ -109,6 +109,18 @@ describe('Datasource Generator', () => {
       expect(result.content).toContain('    SELECT id');
     });
 
+    it('includes backfill skip when provided', () => {
+      const ds = defineDatasource('test_ds', {
+        schema: {
+          id: t.string(),
+        },
+        backfill: 'skip',
+      });
+
+      const result = generateDatasource(ds);
+      expect(result.content).toContain('BACKFILL skip');
+    });
+
     it("includes indexes block when provided", () => {
       const ds = defineDatasource("test_ds", {
         schema: {

--- a/src/generator/datasource.ts
+++ b/src/generator/datasource.ts
@@ -346,6 +346,11 @@ export function generateDatasource(
     parts.push(indexes);
   }
 
+  if (datasource.options.backfill === "skip") {
+    parts.push("");
+    parts.push("BACKFILL skip");
+  }
+
   // Add Kafka configuration if present
   if (datasource.options.kafka) {
     parts.push("");

--- a/src/schema/datasource.test.ts
+++ b/src/schema/datasource.test.ts
@@ -170,6 +170,15 @@ describe("Datasource Schema", () => {
       ]);
     });
 
+    it("accepts backfill skip configuration", () => {
+      const ds = defineDatasource("events_rollup", {
+        schema: { id: t.string() },
+        backfill: "skip",
+      });
+
+      expect(ds.options.backfill).toBe("skip");
+    });
+
     it("validates datasource index fields", () => {
       expect(() =>
         defineDatasource("events", {

--- a/src/schema/datasource.ts
+++ b/src/schema/datasource.ts
@@ -144,6 +144,8 @@ export interface DatasourceOptions<TSchema extends SchemaDefinition> {
   forwardQuery?: string;
   /** Secondary indexes for MergeTree-family engines */
   indexes?: readonly DatasourceIndex[];
+  /** Skip backfilling data when creating a datasource targeted by a materialized view */
+  backfill?: "skip";
   /** Kafka ingestion configuration */
   kafka?: KafkaConfig;
   /** S3 ingestion configuration */


### PR DESCRIPTION
## Summary
- Adds a `backfill: "skip"` option to `defineDatasource`.
- Emits `BACKFILL skip` in generated `.datasource` output when the option is set.
- Adds schema and generator coverage for the new option.

Fixes #161.

## Reproducibility
Before this change, the issue example could not be represented by the SDK: adding `backfill: "skip"` to `defineDatasource(...)` was not part of `DatasourceOptions`, and generated `.datasource` output never included the `BACKFILL skip` directive.

This PR reproduces that path in tests by defining a datasource with:

```ts
defineDatasource("test_ds", {
  schema: { id: t.string() },
  backfill: "skip",
})
```

and asserting the generated `.datasource` content contains:

```datasource
BACKFILL skip
```

## Test plan
- `pnpm exec vitest run src/schema/datasource.test.ts src/generator/datasource.test.ts`
- `pnpm exec tsc --noEmit`
